### PR TITLE
New failing test for parent missing variables

### DIFF
--- a/core/test/missingVariables.test.js
+++ b/core/test/missingVariables.test.js
@@ -308,7 +308,7 @@ transport . avion . usager:
 		expect(result).to.have.lengthOf(2)
 	})
 
-	it("Parent's other descendands in sums should not be included as missing variables, even when parent evluation is triggered by a comparison", function () {
+	it.skip("Parent's other descendands in sums should not be included as missing variables, even when parent evluation is triggered by a comparison", function () {
 		// See https://github.com/betagouv/publicodes/issues/33
 		const rawRules = parse(`
 transport:

--- a/core/test/missingVariables.test.js
+++ b/core/test/missingVariables.test.js
@@ -307,6 +307,55 @@ transport . avion . usager:
 		])
 		expect(result).to.have.lengthOf(2)
 	})
+
+	it("Parent's other descendands in sums should not be included as missing variables, even when parent evluation is triggered by a comparison", function () {
+		// See https://github.com/betagouv/publicodes/issues/33
+		const rawRules = parse(`
+transport:
+  somme: 
+    - voiture
+    - avion
+
+transport . voiture:
+  formule: empreinte * km
+
+transport . voiture . gabarit:
+  question: Quel gabarit ?
+  par défaut: 2
+transport . voiture . empreinte:
+  formule: 
+    variations: 
+      - si: gabarit > 3
+        alors: 800
+      - sinon: 500
+transport . voiture . km: 
+  question: COMBIENKM
+  par défaut: 1000
+
+transport . avion:
+  applicable si: usager
+  formule: empreinte * km
+
+transport . avion . km: 
+  question: COMBIENKM
+  par défaut: 10000
+
+transport . avion . empreinte: 0.300
+
+transport . avion . usager:
+  question: Prenez-vous l'avion ?
+  par défaut: oui
+`)
+		const result = Object.keys(
+			new Engine(rawRules).evaluate('transport . voiture').missingVariables
+		)
+
+		expect(result).deep.to.equal([
+			'transport . voiture . gabarit',
+			'transport . voiture . km',
+		])
+		expect(result).to.have.lengthOf(2)
+	})
 	it("Parent's other descendands in sums should not be included as missing variables - 2", function () {
 		// See https://github.com/betagouv/publicodes/issues/33
 		const rawRules = parse(`


### PR DESCRIPTION
Je mets ici en évidence un problème de l'implé actuelle des missing variables. 
Qui a été introduit via ce commit je pense https://github.com/betagouv/publicodes/commit/d2865e8cd107385b2b8e0e07a8314bfeda08a03d. 

J'ai mis du temps à le trouver, dans ma base de code plus complexe. 

Ce qu'il se passe : 
- on veut calculer `voiture` 
- l'algo va vérifier son parent `transport` 
- c'est une somme, donc comme on le voulait, on n'évalue pas les missing de sa formule
- sauf qu'ensuite, on évalue `empreinte`, qui via une comparaison, fait appel à gabarit. À ce moment, on va alors explorer le parent de `gabarit` , mais sans l'optimisation. 
- on se retrouve alors avec les variables `avion`, aucunement pertinentes pour le calcul ici. 


@mquandalle on retrouve évidemment le fix simple dont on a parlé : ne plus utiliser "transport" à la fois comme parent et comme somme utile, mettre la somme dans `transport . impact`. Ce n'est franchement pas très gênant, mais une subtilité difficile à comprendre.

