### PR TITLE
Publish publicodes-react as ES Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **publicodes-react**
 
+-   Correction d'un type de renderer
 -   Le paquet est désormais publié sous forme d'ES Module
 
 **core**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0-beta.27
+
+**publicodes-react**
+
+-   Le paquet est désormais publié sous forme d'ES Module
+
+**core**
+
+-   Réparation des tests mocha
+
 ## 1.0.0-beta.26
 
 **publicodes-react**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.26",
+	"version": "1.0.0-beta.27",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/types/index.d.ts",
 	"type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,6 @@
 	"bugs": "https://github.com/betagouv/publicodes/issues",
 	"homepage": "https://publi.codes/",
 	"license": "MIT",
-	"readme": "../README.md",
 	"files": [
 		"dist/"
 	],

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"license": "MIT",
-	"readme": "../README.md",
+	"type": "module",
 	"scripts": {
 		"build:mecanisms": "yarn run --silent js-yaml ./source/data/mecanisms.yaml >| ./source/data/mecanisms.json",
 		"prepare": "yarn run build:mecanisms",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.26",
+	"version": "1.0.0-beta.27",
 	"description": "UI to explore publicodes computations",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
 		"yaml": "^1.9.2"
 	},
 	"peerDependencies": {
-		"publicodes": "1.0.0-beta.26",
+		"publicodes": "1.0.0-beta.27",
 		"react": "^17.0.2"
 	},
 	"devDependencies": {

--- a/packages/react-ui/source/contexts.tsx
+++ b/packages/react-ui/source/contexts.tsx
@@ -10,13 +10,14 @@ export type SupportedRenderers = {
 	 * Used to render a rule description or title. Useful to parse markdown, links
 	 * or emojies.
 	 */
-	Text?: React.ComponentType
+	Text?: React.ComponentType<{ children: string }>
 	References?: typeof References
 }
 
-export const DefaultTextRenderer: React.ComponentType = ({ children }) => (
-	<>{children}</>
-)
+export const DefaultTextRenderer: React.ComponentType<{ children: string }> = ({
+	children,
+}) => <>{children}</>
+
 export const BasepathContext = createContext<string>('/documentation')
 export const EngineContext = createContext<Engine<string> | null>(null)
 export const RenderersContext = createContext<

--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -118,7 +118,7 @@ export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 			)}
 			<RuleHeader dottedName={dottedName} />
 			<section>
-				<Text>{description || question}</Text>
+				<Text>{description || question || ''}</Text>
 			</section>
 			{
 				<>

--- a/packages/react-ui/tsconfig.json
+++ b/packages/react-ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"module": "CommonJS",
+		"module": "ES2020",
 		"target": "es2015",
 		"lib": ["es2019", "dom"],
 		"outDir": "./dist/",


### PR DESCRIPTION
Required for the migration of mon-entreprise to vitejs 
https://github.com/betagouv/mon-entreprise/pull/1861