### PR TITLE
Add ability to define max inversion iterations in engine options

### DIFF
--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -72,6 +72,7 @@ type Options = {
 	logger: Logger
 	getUnitKey?: getUnitKey
 	formatUnit?: formatUnit
+	inversionMaxIterations?: number
 }
 
 export type EvaluationFunction<Kind extends NodeKind = NodeKind> = (

--- a/packages/core/source/mecanisms/inversion.ts
+++ b/packages/core/source/mecanisms/inversion.ts
@@ -103,6 +103,7 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 		y1Node.missingVariables,
 		y2Node.missingVariables
 	)
+	const maxIterations = this.options.inversionMaxIterations ?? 10
 
 	if (y1 !== undefined || y2 !== undefined) {
 		// The `uniroot` function parameter. It will be called with its `min` and
@@ -128,7 +129,14 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 				? x1
 				: defaultMax
 
-		nodeValue = uniroot(test, nearestBelowGoal, nearestAboveGoal, 0.1, 10, 1)
+		nodeValue = uniroot(
+			test,
+			nearestBelowGoal,
+			nearestAboveGoal,
+			0.1,
+			maxIterations,
+			1
+		)
 	}
 	if (nodeValue === undefined) {
 		nodeValue = undefined


### PR DESCRIPTION
Un soucis est remonté dans l'utilisation de l'inversion numérique dans une base de règles tierce. Pour solutionner ça il suffisait de monter le nombre d'itérations.

Je propose donc ici d'ajouter le nombre d'itérations en option de `Engine`.