### PR TITLE
Refacto errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-beta.48
+
+**core**
+
+-   Ajout de trois type d'erreurs (`SyntaxError`, `EvaluationError`, `InternalError`) enfant d'`EngineError`
+-   Ajout d'un attribut `rule` au erreurs `SyntaxError` et `EvaluationError`
+-   **⚠ Changement cassant :** La fonction `evaluationError` throw une erreur de type `EvaluationError` au lieu d'un log
+-   Remplace la fonction `neverHappens` par une erreur `UnreachableCaseError`
+
 ## 1.0.0-beta.47
 
 **core**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 -   Ajout d'un attribut `rule` au erreurs `SyntaxError` et `EvaluationError`
 -   **⚠ Changement cassant :** La fonction `evaluationError` throw une erreur de type `EvaluationError` au lieu d'un log
 -   Remplace la fonction `neverHappens` par une erreur `UnreachableCaseError`
+-   Ajout d'une arborescence des règles dans la documentation [#250](https://github.com/betagouv/publicodes/pull/250)
+-   Répare l'inférence d'unité dans une somme avec un élément non applicable [#252](https://github.com/betagouv/publicodes/pull/252)
 
 ## 1.0.0-beta.47
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.47",
+	"version": "1.0.0-beta.48",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/api/source/route/test/__snapshots__/evaluate.test.ts.snap
+++ b/packages/api/source/route/test/__snapshots__/evaluate.test.ts.snap
@@ -3,7 +3,10 @@
 exports[`evaluate > Test error in expression and situation at same time 1`] = `
 {
   "situationError": {
-    "message": "Erreur lors de la mise à jour de la situation : test n'existe pas dans la base de règle.",
+    "message": "
+[ Erreur d'évaluation ]
+➡️  Dans la règle \\"test\\"
+✖️  Erreur lors de la mise à jour de la situation : test n'existe pas dans la base de règle.",
   },
 }
 `;
@@ -11,7 +14,10 @@ exports[`evaluate > Test error in expression and situation at same time 1`] = `
 exports[`evaluate > Test invalid syntax in situation 1`] = `
 {
   "situationError": {
-    "message": "Erreur lors de la mise à jour de la situation : test n'existe pas dans la base de règle.",
+    "message": "
+[ Erreur d'évaluation ]
+➡️  Dans la règle \\"test\\"
+✖️  Erreur lors de la mise à jour de la situation : test n'existe pas dans la base de règle.",
   },
 }
 `;
@@ -127,7 +133,6 @@ A space token based on:
 A space token based on:
     Comparison → Comparable ● %space %comparison %space Comparable
     main →  ● Comparison
-
 ",
       },
     },
@@ -246,7 +251,6 @@ A space token based on:
 A space token based on:
     Comparison → Comparable ● %space %comparison %space Comparable
     main →  ● Comparison
-
 ",
       },
     },
@@ -323,7 +327,6 @@ A number token based on:
     AdditionSubstraction →  ● MultiplicationDivision
     NumericValue →  ● AdditionSubstraction
     main →  ● NumericValue
-
 ",
       },
     },

--- a/packages/api/source/route/test/rules.test.ts
+++ b/packages/api/source/route/test/rules.test.ts
@@ -41,7 +41,10 @@ describe('evaluate', () => {
 		expect(rulesId(engine, 'bad rules')).toMatchInlineSnapshot(`
 			{
 			  "error": {
-			    "message": "La règle 'bad rules' n'existe pas",
+			    "message": "
+			[ Erreur d'évaluation ]
+			➡️  Dans la règle \\"bad rules\\"
+			✖️  La règle 'bad rules' n'existe pas",
 			  },
 			}
 		`)

--- a/packages/api/source/test-e2e/__snapshots__/index.test.ts.snap
+++ b/packages/api/source/test-e2e/__snapshots__/index.test.ts.snap
@@ -111,7 +111,6 @@ A space token based on:
 A space token based on:
     Comparison → Comparable ● %space %comparison %space Comparable
     main →  ● Comparison
-
 ",
       },
     },

--- a/packages/api/source/test-e2e/index.test.ts
+++ b/packages/api/source/test-e2e/index.test.ts
@@ -265,7 +265,10 @@ describe('e2e koa middleware', () => {
 		).resolves.toMatchInlineSnapshot(`
 			{
 			  "error": {
-			    "message": "La règle 'bad rule' n'existe pas",
+			    "message": "
+			[ Erreur d'évaluation ]
+			➡️  Dans la règle \\"bad rule\\"
+			✖️  La règle 'bad rule' n'existe pas",
 			  },
 			}
 		`)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.47",
+	"version": "1.0.0-beta.48",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/core/source/AST/index.ts
+++ b/packages/core/source/AST/index.ts
@@ -1,5 +1,5 @@
 import { ParsedRules } from '..'
-import { InternalError, neverHappens } from '../error'
+import { UnreachableCaseError } from '../error'
 import { TrancheNodes } from '../mecanisms/trancheUtils'
 import { ReplacementRule } from '../replacement'
 import { RuleNode } from '../rule'
@@ -173,8 +173,7 @@ export const traverseASTNode: TraverseFunction<NodeKind> = (fn, node) => {
 			return traverseConditionNode(fn, node)
 
 		default:
-			neverHappens(node)
-			throw new InternalError(node)
+			throw new UnreachableCaseError(node)
 	}
 }
 

--- a/packages/core/source/date.ts
+++ b/packages/core/source/date.ts
@@ -1,3 +1,5 @@
+import { syntaxError } from './error'
+
 export function normalizeDateString(dateString: string): string {
 	let [day, month, year] = dateString.split('/')
 	if (!year) {
@@ -14,7 +16,7 @@ export function normalizeDate(
 ): string {
 	const date = new Date(+year, +month - 1, +day)
 	if (!+date || date.getDate() !== +day) {
-		throw new SyntaxError(`La date ${day}/${month}/${year} n'est pas valide`)
+		syntaxError(`La date ${day}/${month}/${year} n'est pas valide`, {})
 	}
 	return `${pad(day)}/${pad(month)}/${pad(year)}`
 }

--- a/packages/core/source/error.ts
+++ b/packages/core/source/error.ts
@@ -27,10 +27,10 @@ export class EvaluationError extends EngineError {
 	}
 }
 
-export class InternalError extends EngineError {
-	payload: unknown
+export class InternalError<T> extends EngineError {
+	payload: T
 
-	constructor(payload: unknown) {
+	constructor(payload: T) {
 		super(
 			`
 Erreur interne du moteur.
@@ -43,6 +43,16 @@ ${JSON.stringify(payload, null, 2)}
 		)
 		this.name = 'InternalError'
 		this.payload = payload
+	}
+}
+
+/**
+ * Use this error in default case of a switch to check exhaustivity statically
+ * inspired by https://github.com/ts-essentials/ts-essentials#exhaustive-switch-cases
+ */
+export class UnreachableCaseError extends InternalError<never> {
+	constructor(value: never) {
+		super(value)
 	}
 }
 
@@ -90,8 +100,6 @@ export function evaluationError(
 		messageError("Erreur d'évaluation", rule, message, originalError)
 	)
 }
-
-export function neverHappens(_: never) {} // why this ?
 
 export function warning(
 	logger: Logger,

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -1,4 +1,5 @@
 import { type ASTNode, type EvaluatedNode, type NodeKind } from './AST/types'
+import { evaluationError } from './error'
 import { evaluationFunctions } from './evaluationFunctions'
 import parsePublicodes, {
 	Context,
@@ -138,13 +139,15 @@ export default class Engine<Name extends string = string> {
 
 		Object.keys(situation).forEach((name) => {
 			if (!(name in this.baseContext.parsedRules)) {
-				throw new Error(
-					`Erreur lors de la mise à jour de la situation : ${name} n'existe pas dans la base de règle.`
+				evaluationError(
+					`Erreur lors de la mise à jour de la situation : ${name} n'existe pas dans la base de règle.`,
+					{ rule: name }
 				)
 			}
 			if (this.baseContext.parsedRules[name].private) {
-				throw new Error(
-					`Erreur lors de la mise à jour de la situation : ${name} est une règle privée (il n'est pas possible de modifier une règle privée).`
+				evaluationError(
+					`Erreur lors de la mise à jour de la situation : ${name} est une règle privée (il n'est pas possible de modifier une règle privée).`,
+					{ rule: name }
 				)
 			}
 		})
@@ -181,12 +184,17 @@ export default class Engine<Name extends string = string> {
 
 	getRule(dottedName: Name): ParsedRules<Name>[Name] {
 		if (!(dottedName in this.baseContext.parsedRules)) {
-			throw new Error(`La règle '${dottedName}' n'existe pas`)
+			evaluationError(`La règle '${dottedName}' n'existe pas`, {
+				rule: dottedName,
+			})
 		}
 
 		if (!(dottedName in this.publicParsedRules)) {
-			throw new Error(`La règle ${dottedName} est une règle privée.`)
+			evaluationError(`La règle ${dottedName} est une règle privée.`, {
+				rule: dottedName,
+			})
 		}
+
 		return this.publicParsedRules[dottedName]
 	}
 
@@ -229,7 +237,7 @@ export default class Engine<Name extends string = string> {
 		}
 
 		if (!evaluationFunctions[parsedNode.nodeKind]) {
-			throw Error(`Unknown "nodeKind": ${parsedNode.nodeKind}`)
+			evaluationError(`Unknown "nodeKind": ${parsedNode.nodeKind}`, {})
 		}
 
 		const isTraversedVariablesBoundary =

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -55,6 +55,12 @@ export {
 	traverseASTNode,
 } from './AST/index'
 export { type Evaluation, type Unit } from './AST/types'
+export {
+	EngineError,
+	EvaluationError,
+	InternalError,
+	SyntaxError,
+} from './error'
 export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -83,10 +83,7 @@ export type EvaluationFunction<Kind extends NodeKind = NodeKind> = (
 	node: ASTNode & { nodeKind: Kind }
 ) => ASTNode & { nodeKind: Kind } & EvaluatedNode
 
-export type ParsedRules<Name extends string> = Record<
-	Name,
-	RuleNode & { dottedName: Name }
->
+export type ParsedRules<Name extends string> = Record<Name, RuleNode<Name>>
 
 export default class Engine<Name extends string = string> {
 	baseContext: Context<Name>

--- a/packages/core/source/mecanisms/arrondi.ts
+++ b/packages/core/source/mecanisms/arrondi.ts
@@ -32,11 +32,10 @@ const evaluate: EvaluationFunction<'arrondi'> = function (node) {
 			!serializeUnit((arrondi as EvaluatedNode).unit)?.match(/décimales?/)
 		) {
 			evaluationError(
-				// this.context.logger,
-				this.cache._meta.evaluationRuleStack[0],
 				`L'unité ${serializeUnit(
 					(arrondi as EvaluatedNode).unit
-				)} de l'arrondi est inconnu. Vous devez utiliser l'unité “décimales”`
+				)} de l'arrondi est inconnu. Vous devez utiliser l'unité “décimales”`,
+				{ rule: this.cache._meta.evaluationRuleStack[0] }
 			)
 		}
 	}

--- a/packages/core/source/mecanisms/arrondi.ts
+++ b/packages/core/source/mecanisms/arrondi.ts
@@ -32,7 +32,7 @@ const evaluate: EvaluationFunction<'arrondi'> = function (node) {
 			!serializeUnit((arrondi as EvaluatedNode).unit)?.match(/décimales?/)
 		) {
 			evaluationError(
-				this.context.logger,
+				// this.context.logger,
 				this.cache._meta.evaluationRuleStack[0],
 				`L'unité ${serializeUnit(
 					(arrondi as EvaluatedNode).unit

--- a/packages/core/source/mecanisms/condition.ts
+++ b/packages/core/source/mecanisms/condition.ts
@@ -20,11 +20,9 @@ const evaluate: EvaluationFunction<'condition'> = function (node) {
 	let alors = node.explanation.alors
 	let sinon = node.explanation.sinon
 	if ('unit' in condition) {
-		evaluationError(
-			this.context.logger,
-			this.cache._meta.evaluationRuleStack[0],
-			'La condition doit être de type booléen'
-		)
+		evaluationError('La condition doit être de type booléen', {
+			rule: this.cache._meta.evaluationRuleStack[0],
+		})
 	}
 	if (condition.nodeValue === true) {
 		alors = this.evaluateNode(node.explanation.alors)
@@ -43,11 +41,9 @@ const evaluate: EvaluationFunction<'condition'> = function (node) {
 			missingVariables: mergeAllMissing([sinon, alors]),
 		}
 	} else {
-		evaluationError(
-			this.context.logger,
-			this.cache._meta.evaluationRuleStack[0],
-			'La condition doit être de type booléen'
-		)
+		evaluationError('La condition doit être de type booléen', {
+			rule: this.cache._meta.evaluationRuleStack[0],
+		})
 	}
 	const unit = evaluation.unit ?? (alors as any).unit
 	return {

--- a/packages/core/source/mecanisms/inlineMecanism.ts
+++ b/packages/core/source/mecanisms/inlineMecanism.ts
@@ -48,10 +48,7 @@ export function createParseInlinedMecanism(
 			if (argName in parsedDefaultArgs) {
 				return parsedDefaultArgs[argName]
 			}
-			syntaxError(
-				context,
-				`Il manque la clé '${argName} dans le mécanisme ${name}`
-			)
+			syntaxError(`Il manque la clé '${argName} dans le mécanisme ${name}`, {})
 		})(parsedBody)
 		parsedInlineMecanism.sourceMap = {
 			mecanismName: name,

--- a/packages/core/source/mecanisms/trancheUtils.ts
+++ b/packages/core/source/mecanisms/trancheUtils.ts
@@ -109,7 +109,7 @@ export function evaluatePlafondUntilActiveTranche(
 				(plafondValue as number) <= plancherValue
 			) {
 				evaluationError(
-					this.context.logger,
+					// this.options.logger,
 					this.cache._meta.evaluationRuleStack[0],
 					`Le plafond de la tranche n°${
 						i + 1

--- a/packages/core/source/mecanisms/trancheUtils.ts
+++ b/packages/core/source/mecanisms/trancheUtils.ts
@@ -70,10 +70,10 @@ export function evaluatePlafondUntilActiveTranche(
 			} catch (e) {
 				warning(
 					this.context.logger,
-					this.cache._meta.evaluationRuleStack[0],
 					`L'unité du plafond de la tranche n°${
 						i + 1
 					}  n'est pas compatible avec celle l'assiette`,
+					{ rule: this.cache._meta.evaluationRuleStack[0] },
 					e
 				)
 			}
@@ -109,11 +109,10 @@ export function evaluatePlafondUntilActiveTranche(
 				(plafondValue as number) <= plancherValue
 			) {
 				evaluationError(
-					// this.options.logger,
-					this.cache._meta.evaluationRuleStack[0],
 					`Le plafond de la tranche n°${
 						i + 1
-					} a une valeur inférieure à celui de la tranche précédente`
+					} a une valeur inférieure à celui de la tranche précédente`,
+					{ rule: this.cache._meta.evaluationRuleStack[0] }
 				)
 			}
 

--- a/packages/core/source/mecanisms/unité.ts
+++ b/packages/core/source/mecanisms/unité.ts
@@ -37,8 +37,8 @@ registerEvaluationFunction(parseUnité.nom, function evaluate(node) {
 		} catch (e) {
 			warning(
 				this.context.logger,
-				this.cache._meta.evaluationRuleStack[0],
 				"Erreur lors de la conversion d'unité explicite",
+				{ rule: this.cache._meta.evaluationRuleStack[0] },
 				e
 			)
 		}

--- a/packages/core/source/mecanisms/variations.ts
+++ b/packages/core/source/mecanisms/variations.ts
@@ -109,10 +109,10 @@ const evaluate: EvaluationFunction<'variations'> = function (node) {
 					} catch (e) {
 						warning(
 							this.context.logger,
-							this.cache._meta.evaluationRuleStack[0],
 							`L'unité de la branche n° ${
 								i + 1
 							} du mécanisme 'variations' n'est pas compatible avec celle d'une branche précédente`,
+							{ rule: this.cache._meta.evaluationRuleStack[0] },
 							e
 						)
 					}

--- a/packages/core/source/parse.ts
+++ b/packages/core/source/parse.ts
@@ -48,18 +48,18 @@ const { Grammar, Parser } = nearley
 export default function parse(rawNode, context: Context): ASTNode {
 	if (rawNode == undefined) {
 		syntaxError(
-			context.dottedName,
 			`
 Une des valeurs de la formule est vide.
-Vérifiez que tous les champs à droite des deux points sont remplis`
+Vérifiez que tous les champs à droite des deux points sont remplis`,
+			{ rule: context.dottedName }
 		)
 	}
 	if (typeof rawNode === 'boolean') {
 		syntaxError(
-			context.dottedName,
 			`
 Les valeurs booléennes true / false ne sont acceptées.
-Utilisez leur contrepartie française : 'oui' / 'non'`
+Utilisez leur contrepartie française : 'oui' / 'non'`,
+			{ rule: context.dottedName }
 		)
 	}
 	const node =
@@ -106,8 +106,8 @@ function parseExpression(
 			throw e
 		}
 		syntaxError(
-			context.dottedName,
 			`\`${singleLineExpression}\` n'est pas une expression valide`,
+			{ rule: context.dottedName },
 			e
 		)
 	}
@@ -116,26 +116,26 @@ function parseExpression(
 function parseMecanism(rawNode, context: Context) {
 	if (Array.isArray(rawNode)) {
 		syntaxError(
-			context.dottedName,
 			`
 Il manque le nom du mécanisme pour le tableau : [${rawNode
 				.map((x) => `'${x}'`)
 				.join(', ')}]
 Les mécanisme possibles sont : 'somme', 'le maximum de', 'le minimum de', 'toutes ces conditions', 'une de ces conditions'.
-		`
+		`,
+			{ rule: context.dottedName }
 		)
 	}
 
 	const keys = Object.keys(rawNode)
 	if (keys.length > 1) {
 		syntaxError(
-			context.dottedName,
 			`
 Les mécanismes suivants se situent au même niveau : ${keys
 				.map((x) => `'${x}'`)
 				.join(', ')}
 Cela vient probablement d'une erreur dans l'indentation
-	`
+	`,
+			{ rule: context.dottedName }
 		)
 	}
 	if (keys.length === 0) {
@@ -148,10 +148,10 @@ Cela vient probablement d'une erreur dans l'indentation
 
 	if (!parseFn) {
 		syntaxError(
-			context.dottedName,
 			`Le mécanisme "${mecanismName}" est inconnu.
 
-Vérifiez qu'il n'y ait pas d'erreur dans l'orthographe du nom.`
+Vérifiez qu'il n'y ait pas d'erreur dans l'orthographe du nom.`,
+			{ rule: context.dottedName }
 		)
 	}
 	try {
@@ -168,11 +168,11 @@ Vérifiez qu'il n'y ait pas d'erreur dans l'orthographe du nom.`
 			throw e
 		}
 		syntaxError(
-			context.dottedName,
 			mecanismName
 				? `➡️ Dans le mécanisme ${mecanismName}
 ${e.message}`
-				: e.message
+				: e.message,
+			{ rule: context.dottedName }
 		)
 	}
 }

--- a/packages/core/source/parsePublicodes.ts
+++ b/packages/core/source/parsePublicodes.ts
@@ -1,5 +1,6 @@
-import { Logger, ParsedRules } from '.'
+import { EngineError, Logger, ParsedRules } from '.'
 import { makeASTTransformer, traverseParsedRules } from './AST'
+import { syntaxError } from './error'
 import inferNodeType, { NodesTypes } from './inferNodeType'
 import parse from './parse'
 import { inlineReplacements, ReplacementRule } from './replacement'
@@ -74,7 +75,7 @@ export default function parsePublicodes<
 	// STEP 1 : get the rules as an object
 
 	if (typeof rawRules === 'string')
-		throw Error(
+		throw new EngineError(
 			'Publicodes does not parse yaml rule sets itself anymore. Please provide a parsed js object. E.g. the `eemeli/yaml` package.'
 		)
 	let rules = { ...rawRules }
@@ -91,8 +92,9 @@ export default function parsePublicodes<
 			}
 		}
 		if (typeof rule !== 'object') {
-			throw new SyntaxError(
-				`Rule ${dottedName} is incorrectly written. Please give it a proper value.`
+			syntaxError(
+				`Rule ${dottedName} is incorrectly written. Please give it a proper value.`,
+				{ rule: dottedName }
 			)
 		}
 		parse({ nom: dottedName, ...rule }, context)

--- a/packages/core/source/replacement.ts
+++ b/packages/core/source/replacement.ts
@@ -166,12 +166,12 @@ export function inlineReplacements<
 	newRuleNamesWithPreviousReplacements.forEach((name) => {
 		parsedRules[name] = inlinePreviousReplacement(
 			parsedRules[name]
-		) as RuleNode & { dottedName: Names }
+		) as RuleNode<Names>
 	})
 	ruleNamesWithNewReplacements.forEach((name) => {
-		parsedRules[name] = inlineNewReplacement(parsedRules[name]) as RuleNode & {
-			dottedName: Names
-		}
+		parsedRules[name] = inlineNewReplacement(
+			parsedRules[name]
+		) as RuleNode<Names>
 	})
 
 	return [parsedRules, replacements]

--- a/packages/core/source/replacement.ts
+++ b/packages/core/source/replacement.ts
@@ -270,7 +270,6 @@ function replace(
 		if (displayVerboseWarning) {
 			warning(
 				logger,
-				node.contextDottedName,
 				`
 				Il existe plusieurs remplacements pour la référence '${node.dottedName}'.
 				Lors de l'execution, ils seront résolus dans l'odre suivant :
@@ -278,7 +277,8 @@ function replace(
 					(replacement) =>
 						`\n\t- Celui définit dans la règle '${replacement.definitionRule.dottedName}'`
 				)}
-					`
+					`,
+				{ rule: node.contextDottedName }
 			)
 		}
 	}

--- a/packages/core/source/rule.ts
+++ b/packages/core/source/rule.ts
@@ -1,6 +1,6 @@
 import Engine from '.'
 import { ASTNode, EvaluatedNode, MissingVariables } from './AST/types'
-import { warning } from './error'
+import { evaluationError, warning } from './error'
 import { registerEvaluationFunction } from './evaluationFunctions'
 import { defaultNode, mergeMissing } from './evaluationUtils'
 import { capitalise0 } from './format'
@@ -82,7 +82,9 @@ export default function parseRule(
 	const title = capitalise0(rawRule['titre'] ?? name)
 
 	if (context.parsedRules[dottedName]) {
-		throw new Error(`La référence '${dottedName}' a déjà été définie`)
+		evaluationError(`La référence '${dottedName}' a déjà été définie`, {
+			rule: dottedName,
+		})
 	}
 
 	const ruleValue: Record<string, unknown> = {
@@ -183,7 +185,6 @@ registerEvaluationFunction('rule', function evaluate(node) {
 		) {
 			warning(
 				this.context.logger,
-				node.dottedName,
 				`
 						Un cycle a été détecté dans lors de l'évaluation de cette règle.
 		Par défaut cette règle sera évaluée à 'null'.
@@ -192,7 +193,8 @@ registerEvaluationFunction('rule', function evaluate(node) {
 		${node.dottedName}:
 		"résoudre la référence circulaire: oui"
 		...
-		`
+		`,
+				{ rule: node.dottedName }
 			)
 
 			valeurEvaluation = {

--- a/packages/core/source/rule.ts
+++ b/packages/core/source/rule.ts
@@ -50,8 +50,8 @@ type Remplace =
 	| string
 type RendNonApplicable = Exclude<Remplace, { par: any }>
 
-export type RuleNode = {
-	dottedName: string
+export type RuleNode<Name extends string = string> = {
+	dottedName: Name
 	title: string
 	nodeKind: 'rule'
 	virtualRule: boolean

--- a/packages/core/source/ruleUtils.ts
+++ b/packages/core/source/ruleUtils.ts
@@ -1,6 +1,6 @@
 import { ParsedRules } from '.'
 import { ASTNode } from './AST/types'
-import { syntaxError } from './error'
+import { evaluationError, syntaxError } from './error'
 import { ReferencesMaps } from './parsePublicodes'
 import { ReferenceNode } from './reference'
 import { RuleNode } from './rule'
@@ -64,7 +64,7 @@ export function isAccessible(
 	name: string
 ) {
 	if (!(name in rules)) {
-		throw new Error("La règle n'existe pas")
+		evaluationError(`La règle "${name}" n'existe pas`, { rule: name })
 	}
 
 	const commonAncestor = findCommonAncestor(contextName, name)
@@ -97,20 +97,19 @@ export function disambiguateReference<R extends Record<string, RuleNode>>(
 
 	if (!existingDottedName.length) {
 		syntaxError(
-			contextName,
 			`La référence "${partialName}" est introuvable.
-Vérifiez que l'orthographe et l'espace de nom sont corrects`
+Vérifiez que l'orthographe et l'espace de nom sont corrects`,
+			{ rule: contextName }
 		)
-		throw new Error()
 	}
 	if (!accessibleDottedName) {
 		syntaxError(
-			contextName,
 			`La règle "${existingDottedName[0]}" n'est pas accessible depuis "${contextName}".
-Cela vient du fait qu'elle est privée ou qu'un de ses parent est privé`
+Cela vient du fait qu'elle est privée ou qu'un de ses parent est privé`,
+			{ rule: contextName }
 		)
-		throw new Error()
 	}
+
 	return accessibleDottedName
 }
 

--- a/packages/core/test/ruleUtils.test.ts
+++ b/packages/core/test/ruleUtils.test.ts
@@ -39,7 +39,9 @@ function createDummyRule(
 
 describe('isAccessible', () => {
 	it("should throws if rule to check doesn't exists", () => {
-		expect(() => isAccessible({}, '', 'a')).to.throw("La règle n'existe pas")
+		expect(() => isAccessible({}, '', 'a')).to.throw(
+			'\n[ Erreur d\'évaluation ]\n➡️  Dans la règle "a"\n✖️  La règle "a" n\'existe pas'
+		)
 	})
 
 	it('should return true if no rules are private', () => {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.47",
+	"version": "1.0.0-beta.48",
 	"description": "UI to explore publicodes computations",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/react-ui/source/Explanation.tsx
+++ b/packages/react-ui/source/Explanation.tsx
@@ -1,6 +1,5 @@
 import { transformAST } from 'publicodes'
-import { useContext } from 'react'
-import { EngineContext } from './contexts'
+import { useEngine } from './hooks'
 import Arrondi from './mecanisms/Arrondi'
 import Avec from './mecanisms/Avec'
 import Barème from './mecanisms/Barème'
@@ -61,10 +60,7 @@ const UIComponents = {
 
 export default function Explanation({ node }) {
 	const visualisationKind = node.sourceMap?.mecanismName ?? node.nodeKind
-	const engine = useContext(EngineContext)
-	if (!engine) {
-		throw new Error('We need an engine instance in the React context')
-	}
+	const engine = useEngine()
 	const evaluateEverything = transformAST((node) => {
 		if ('nodeValue' in node || 'replacementRule' === node.nodeKind) {
 			return false

--- a/packages/react-ui/source/RuleLink.tsx
+++ b/packages/react-ui/source/RuleLink.tsx
@@ -1,6 +1,7 @@
 import Engine, { utils } from 'publicodes'
 import React, { useContext } from 'react'
-import { BasepathContext, EngineContext, RenderersContext } from './contexts'
+import { BasepathContext, RenderersContext } from './contexts'
+import { useEngine } from './hooks'
 
 const { encodeRuleName } = utils
 
@@ -70,10 +71,7 @@ export function RuleLinkWithContext(
 		useSubEngine?: boolean
 	}
 ) {
-	const engine = useContext(EngineContext)
-	if (!engine) {
-		throw new Error('an engine should be provided in context')
-	}
+	const engine = useEngine()
 	const documentationPath = useContext(BasepathContext)
 	const currentEngineIdFromUrl = new URLSearchParams(
 		window.location.search

--- a/packages/react-ui/source/hooks.ts
+++ b/packages/react-ui/source/hooks.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { EngineContext } from './contexts'
+
+export const useEngine = () => {
+	const engine = useContext(EngineContext)
+	if (!engine) {
+		throw new Error('Engine expected')
+	}
+
+	return engine
+}

--- a/packages/react-ui/source/mecanisms/Recalcul.tsx
+++ b/packages/react-ui/source/mecanisms/Recalcul.tsx
@@ -1,8 +1,8 @@
 import { EvaluatedNode } from 'publicodes'
 import { RecalculNode } from 'publicodes/source/mecanisms/recalcul'
-import { useContext } from 'react'
 import { EngineContext } from '../contexts'
 import Explanation from '../Explanation'
+import { useEngine } from '../hooks'
 import { RuleLinkWithContext } from '../RuleLink'
 import { Mecanism } from './common'
 
@@ -11,10 +11,7 @@ export default function Recalcul({
 	explanation,
 	unit,
 }: RecalculNode & EvaluatedNode) {
-	const engine = useContext(EngineContext)
-	if (!engine) {
-		throw new Error()
-	}
+	const engine = useEngine()
 	const recalculEngine = explanation.subEngineId
 		? engine.subEngines[explanation.subEngineId]
 		: engine

--- a/packages/react-ui/source/mecanisms/Reference.tsx
+++ b/packages/react-ui/source/mecanisms/Reference.tsx
@@ -17,7 +17,7 @@ export default function Reference(
 	const { dottedName, nodeValue, unit } = node
 	const rule = engine?.context.parsedRules[node.dottedName]
 	if (!rule) {
-		throw new Error('Unknown node')
+		throw new Error(`Unknown rule: ${dottedName}`)
 	}
 	const [folded, setFolded] = useState(true)
 	const isFoldEnabled = useContext(UnfoldIsEnabledContext)

--- a/packages/react-ui/source/rule/Header.tsx
+++ b/packages/react-ui/source/rule/Header.tsx
@@ -1,14 +1,10 @@
 import { utils } from 'publicodes'
-import { useContext } from 'react'
-import { EngineContext } from '../contexts'
+import { useEngine } from '../hooks'
 import { RuleLinkWithContext } from '../RuleLink'
 import Meta from './Meta'
 
 export default function RuleHeader({ dottedName }) {
-	const engine = useContext(EngineContext)
-	if (!engine) {
-		throw new Error('an engine should be provided in context')
-	}
+	const engine = useEngine()
 	const {
 		title,
 		rawNode: { description, question, icônes },

--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -14,6 +14,7 @@ import {
 	SupportedRenderers,
 } from '../contexts'
 import Explanation from '../Explanation'
+import { useEngine } from '../hooks'
 import { RuleLinkWithContext } from '../RuleLink'
 import RuleHeader from './Header'
 import { breakpointsWidth, RulesNav } from './RulesNav'
@@ -75,11 +76,8 @@ type RuleProps = {
 }
 
 export function Rule({ dottedName, language, subEngineId }: RuleProps) {
-	const baseEngine = useContext(EngineContext)
+	const baseEngine = useEngine()
 	const { References, Text } = useContext(RenderersContext)
-	if (!baseEngine) {
-		throw new Error('Engine expected')
-	}
 
 	const useSubEngine =
 		subEngineId && baseEngine.subEngines.length >= subEngineId

--- a/packages/react-ui/source/rule/RulesNav.tsx
+++ b/packages/react-ui/source/rule/RulesNav.tsx
@@ -1,15 +1,8 @@
 import { utils } from 'publicodes'
-import {
-	memo,
-	useCallback,
-	useContext,
-	useEffect,
-	useRef,
-	useState,
-} from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 import styled from 'styled-components'
-import { EngineContext } from '../contexts'
+import { useEngine } from '../hooks'
 import { ArrowDown, ArrowUp } from '../icons'
 import { RuleLinkWithContext } from '../RuleLink'
 
@@ -18,12 +11,8 @@ interface Props {
 }
 
 export const RulesNav = ({ dottedName }: Props) => {
-	const baseEngine = useContext(EngineContext)
+	const baseEngine = useEngine()
 	const [navOpen, setNavOpen] = useState(false)
-
-	if (!baseEngine) {
-		throw new Error('Engine expected')
-	}
 
 	const initLevel = (dn: string) =>
 		Object.fromEntries([
@@ -111,11 +100,7 @@ export const RulesNav = ({ dottedName }: Props) => {
 }
 
 const NavLi = ({ ruleDottedName, open, active, onClickDropdown }) => {
-	const baseEngine = useContext(EngineContext)
-
-	if (!baseEngine) {
-		throw new Error('Engine expected')
-	}
+	const baseEngine = useEngine()
 
 	const parsedRules = baseEngine.getParsedRules()
 	const childrenCount = Object.keys(parsedRules).reduce(


### PR DESCRIPTION
- Ajout de trois erreurs `SyntaxError`, `EvaluationError`, `InternalError` enfant d'`EngineError`
- Ajout de `rule` (le `dottedName`) au erreurs `SyntaxError` et `EvaluationError`
- La fonction `evaluationError` throw une erreur `EvaluationError` au lieu d'un log
- Remplace la fonction `neverHappens` par une erreur `UnreachableCaseError`
