### PR TITLE
Restaure les missingVariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+**core**
+
+-   Restaure la précédente implémentation des variables manquantes (pre beta.33)
+
 ## 1.0.0-beta.36
 
 **core**

--- a/packages/core/source/AST/types.ts
+++ b/packages/core/source/AST/types.ts
@@ -107,6 +107,8 @@ export type Unit = {
 	denominators: Array<BaseUnit>
 }
 
+export type MissingVariables = Record<string, number>
+
 // Idée : une évaluation est un n-uple : (value, unit, missingVariable, isApplicable)
 type EvaluationDecoration<T extends Types> = {
 	nodeValue: Evaluation<T>
@@ -116,7 +118,7 @@ type EvaluationDecoration<T extends Types> = {
 	}
 	unit?: Unit
 	traversedVariables?: Array<string>
-	missingVariables?: Array<string>
+	missingVariables: MissingVariables
 }
 export type Types = number | boolean | string | Record<string, unknown>
 // TODO: type NotYetDefined & NotApplicable properly (see #14) then refactor any code depending on these:

--- a/packages/core/source/evaluation.ts
+++ b/packages/core/source/evaluation.ts
@@ -1,8 +1,37 @@
 import Engine, { EvaluationFunction } from '.'
-import { ConstantNode, Evaluation, NodeKind } from './AST/types'
+import {
+	ConstantNode,
+	Evaluation,
+	EvaluatedNode,
+	ASTNode,
+	NodeKind,
+} from './AST/types'
 import { warning } from './error'
 import { convertNodeToUnit } from './nodeUnits'
 import parse from './parse'
+
+export const collectNodeMissing = (
+	node: EvaluatedNode | ASTNode
+): Record<string, number> =>
+	'missingVariables' in node ? node.missingVariables : {}
+
+export const bonus = (missings: Record<string, number> = {}) =>
+	Object.fromEntries(
+		Object.entries(missings).map(([key, value]) => [key, value + 0.0001])
+	)
+export const mergeMissing = (
+	left: Record<string, number> | undefined = {},
+	right: Record<string, number> | undefined = {}
+): Record<string, number> =>
+	Object.fromEntries(
+		[...Object.keys(left), ...Object.keys(right)].map((key) => [
+			key,
+			(left[key] ?? 0) + (right[key] ?? 0),
+		])
+	)
+
+export const mergeAllMissing = (missings: Array<EvaluatedNode | ASTNode>) =>
+	missings.map(collectNodeMissing).reduce(mergeMissing, {})
 
 function convertNodesToSameUnit(this: Engine, nodes, mecanismName) {
 	const firstNodeWithUnit = nodes.find((node) => !!node.unit)

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -4,7 +4,6 @@ import { evaluationFunctions } from './evaluationFunctions'
 import parse from './parse'
 import parsePublicodes, {
 	disambiguateReferenceAndCollectDependencies,
-	getVariablesExpectedInSituation,
 	InferedType,
 } from './parsePublicodes'
 import {
@@ -118,7 +117,6 @@ export default class Engine<Name extends string = string> {
 
 	ruleUnits: WeakMap<ASTNode, InferedType>
 	rulesDependencies: ReturnType<typeof parsePublicodes>['rulesDependencies']
-	variablesExpectedInSituation: Array<Name>
 
 	constructor(
 		rules: string | Record<string, Rule> = {},
@@ -133,9 +131,6 @@ export default class Engine<Name extends string = string> {
 		this.ruleUnits = ruleUnits
 		this.rulesDependencies = rulesDependencies
 		this.replacements = getReplacements(this.parsedRules)
-		this.variablesExpectedInSituation = getVariablesExpectedInSituation(
-			this.parsedRules
-		)
 	}
 
 	setOptions(options: Partial<Options>) {
@@ -252,7 +247,6 @@ export default class Engine<Name extends string = string> {
 			evaluatedNode.traversedVariables = Array.from(
 				this.cache._meta.traversedVariablesStack.shift() ?? []
 			)
-			evaluatedNode.missingVariables = this.missingVariables(evaluatedNode)
 
 			if (this.cache._meta.traversedVariablesStack.length > 0) {
 				evaluatedNode.traversedVariables.forEach((name) => {
@@ -281,15 +275,6 @@ export default class Engine<Name extends string = string> {
 		}
 
 		return isApplicable.call(this, node)
-	}
-
-	missingVariables(evaluatedNode: any) {
-		return evaluatedNode.traversedVariables.filter(
-			(name: Name) =>
-				this.variablesExpectedInSituation.includes(name) &&
-				!Object.keys(this.parsedSituation).includes(name) &&
-				this.isApplicable(this.parsedRules[name])
-		)
 	}
 
 	/**

--- a/packages/core/source/mecanisms/abattement.ts
+++ b/packages/core/source/mecanisms/abattement.ts
@@ -1,6 +1,7 @@
 import { EvaluationFunction, serializeUnit } from '..'
 import { ASTNode } from '../AST/types'
 import { warning } from '../error'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -49,6 +50,7 @@ const evaluateAbattement: EvaluationFunction<'abattement'> = function (node) {
 		...node,
 		nodeValue,
 		unit: assiette.unit,
+		missingVariables: mergeAllMissing([assiette, abattement]),
 		explanation: {
 			assiette,
 			abattement,

--- a/packages/core/source/mecanisms/applicable.ts
+++ b/packages/core/source/mecanisms/applicable.ts
@@ -1,5 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode } from '../AST/types'
+import { bonus, mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -27,6 +28,10 @@ const evaluate: EvaluationFunction<'applicable si'> = function (node) {
 				? null
 				: (valeur as EvaluatedNode)?.nodeValue,
 		explanation: { valeur, condition },
+		missingVariables: mergeMissing(
+			'missingVariables' in valeur ? valeur.missingVariables : {},
+			bonus(condition.missingVariables)
+		),
 		...('unit' in valeur && { unit: valeur.unit }),
 	}
 }

--- a/packages/core/source/mecanisms/arrondi.ts
+++ b/packages/core/source/mecanisms/arrondi.ts
@@ -1,6 +1,7 @@
 import { EvaluationFunction, simplifyNodeUnit } from '..'
 import { ASTNode, EvaluatedNode } from '../AST/types'
 import { evaluationError } from '../error'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 import { serializeUnit } from '../units'
@@ -53,6 +54,7 @@ const evaluate: EvaluationFunction<'arrondi'> = function (node) {
 				? undefined
 				: valeur.nodeValue,
 		explanation: { valeur, arrondi },
+		missingVariables: mergeAllMissing([valeur, arrondi]),
 		unit: valeur.unit,
 	}
 }

--- a/packages/core/source/mecanisms/barème.ts
+++ b/packages/core/source/mecanisms/barème.ts
@@ -1,6 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
-import { defaultNode } from '../evaluation'
+import { defaultNode, mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 import { convertUnit, parseUnit } from '../units'
@@ -39,6 +39,7 @@ function evaluateBarème(tranches, assiette, evaluate) {
 			return { ...tranche, nodeValue: 0 }
 		}
 		const taux = evaluate(tranche.taux)
+		const missingVariables = mergeAllMissing([taux, tranche])
 
 		if (
 			[
@@ -52,6 +53,7 @@ function evaluateBarème(tranches, assiette, evaluate) {
 				...tranche,
 				taux,
 				nodeValue: undefined,
+				missingVariables,
 			}
 		}
 		return {
@@ -62,6 +64,7 @@ function evaluateBarème(tranches, assiette, evaluate) {
 				(Math.min(assiette.nodeValue, tranche.plafondValue) -
 					tranche.plancherValue) *
 				convertUnit(taux.unit, parseUnit(''), taux.nodeValue as number),
+			missingVariables,
 		}
 	})
 }
@@ -87,6 +90,7 @@ const evaluate: EvaluationFunction<'barème'> = function (node) {
 	return {
 		...node,
 		nodeValue,
+		missingVariables: mergeAllMissing([assiette, multiplicateur, ...tranches]),
 		explanation: {
 			assiette,
 			multiplicateur,

--- a/packages/core/source/mecanisms/condition-allof.ts
+++ b/packages/core/source/mecanisms/condition-allof.ts
@@ -1,5 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -31,6 +32,7 @@ const evaluate: EvaluationFunction<'toutes ces conditions'> = function (node) {
 		...node,
 		nodeValue,
 		explanation,
+		missingVariables: mergeAllMissing(explanation),
 	}
 }
 

--- a/packages/core/source/mecanisms/condition-oneof.ts
+++ b/packages/core/source/mecanisms/condition-oneof.ts
@@ -1,18 +1,26 @@
 import { EvaluationFunction } from '..'
-import { ASTNode, EvaluatedNode, Evaluation } from '../AST/types'
+import {
+	ASTNode,
+	EvaluatedNode,
+	Evaluation,
+	MissingVariables,
+} from '../AST/types'
 import { InternalError } from '../error'
+import { mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
 export type UneDeCesConditionsNode = {
 	explanation: Array<ASTNode>
 	nodeKind: 'une de ces conditions'
+	missingVariables: MissingVariables
 }
 
 const evaluate: EvaluationFunction<'une de ces conditions'> = function (node) {
 	type Calculations = {
 		explanation: Array<ASTNode | EvaluatedNode>
 		nodeValue: Evaluation<boolean>
+		missingVariables: MissingVariables
 	}
 	const calculations = node.explanation.reduce<Calculations>(
 		(acc, node) => {
@@ -30,6 +38,10 @@ const evaluate: EvaluationFunction<'une de ces conditions'> = function (node) {
 						: evaluatedNode.nodeValue === undefined
 						? undefined
 						: acc.nodeValue,
+					missingVariables: mergeMissing(
+						acc.missingVariables,
+						evaluatedNode.missingVariables
+					),
 					explanation: [...acc.explanation, evaluatedNode],
 				}
 			}
@@ -37,6 +49,7 @@ const evaluate: EvaluationFunction<'une de ces conditions'> = function (node) {
 		},
 		{
 			nodeValue: false,
+			missingVariables: {},
 			explanation: [],
 		}
 	)

--- a/packages/core/source/mecanisms/durée.ts
+++ b/packages/core/source/mecanisms/durée.ts
@@ -1,7 +1,7 @@
 import { EvaluationFunction } from '..'
 import { ASTNode, Unit } from '../AST/types'
 import { convertToDate, convertToString } from '../date'
-import { defaultNode, parseObject } from '../evaluation'
+import { defaultNode, mergeAllMissing, parseObject } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { parseUnit } from '../units'
 
@@ -38,6 +38,7 @@ const evaluate: EvaluationFunction<'durée'> = function (node) {
 	}
 	return {
 		...node,
+		missingVariables: mergeAllMissing([from, to]),
 		nodeValue,
 		explanation: {
 			depuis: from,

--- a/packages/core/source/mecanisms/grille.ts
+++ b/packages/core/source/mecanisms/grille.ts
@@ -1,6 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
-import { defaultNode } from '../evaluation'
+import { defaultNode, mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 import {
@@ -52,6 +52,7 @@ const evaluate: EvaluationFunction<'grille'> = function (node) {
 				montant,
 				nodeValue: montant.nodeValue,
 				unit: montant.unit,
+				missingVariables: mergeAllMissing([montant, tranche]),
 			}
 		})
 
@@ -76,6 +77,11 @@ const evaluate: EvaluationFunction<'grille'> = function (node) {
 	return {
 		...node,
 		nodeValue,
+		missingVariables: mergeAllMissing([
+			assiette,
+			multiplicateur,
+			...activeTranches,
+		]),
 		explanation: {
 			...node.explanation,
 			assiette,

--- a/packages/core/source/mecanisms/inversion.ts
+++ b/packages/core/source/mecanisms/inversion.ts
@@ -1,5 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ConstantNode, Unit } from '../AST/types'
+import { mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -39,6 +40,15 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 		return {
 			...node,
 			nodeValue: undefined,
+			missingVariables: {
+				...Object.fromEntries(
+					node.explanation.inversionCandidates.map((candidate) => [
+						candidate.dottedName,
+						1,
+					])
+				),
+				[node.explanation.ruleToInverse]: 1,
+			},
 		}
 	}
 	const evaluatedInversionGoal = this.evaluate(inversionGoal)
@@ -151,6 +161,10 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 			inversionGoal,
 			inversionNumberOfIterations,
 		},
+		missingVariables: mergeMissing(
+			y1Node.missingVariables,
+			y2Node.missingVariables
+		),
 	}
 }
 

--- a/packages/core/source/mecanisms/nonApplicable.ts
+++ b/packages/core/source/mecanisms/nonApplicable.ts
@@ -1,5 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode } from '../AST/types'
+import { bonus, mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -28,6 +29,10 @@ const evaluate: EvaluationFunction<'non applicable si'> = function (node) {
 				? (valeur as EvaluatedNode).nodeValue
 				: undefined,
 		explanation: { valeur, condition },
+		missingVariables: mergeMissing(
+			'missingVariables' in valeur ? valeur.missingVariables : {},
+			bonus(condition.missingVariables)
+		),
 		...('unit' in valeur && { unit: valeur.unit }),
 	}
 }

--- a/packages/core/source/mecanisms/one-possibility.ts
+++ b/packages/core/source/mecanisms/one-possibility.ts
@@ -22,9 +22,11 @@ export const mecanismOnePossibility = (v, context: Context) => {
 			parse(p, { ...context, circularReferences: true })
 		),
 		nodeKind: 'une possibilité',
+		context: context.dottedName,
 	} as PossibilityNode
 }
 registerEvaluationFunction<'une possibilité'>('une possibilité', (node) => ({
 	...node,
 	nodeValue: undefined,
+	missingVariables: { [node.context]: 1 },
 }))

--- a/packages/core/source/mecanisms/operation.ts
+++ b/packages/core/source/mecanisms/operation.ts
@@ -45,9 +45,10 @@ const evaluate: EvaluationFunction<'operation'> = function (node) {
 		EvaluatedNode
 	]
 	let [node1, node2] = explanation
+	const missingVariables = mergeAllMissing([node1, node2])
 
 	if (node1.nodeValue === undefined || node2.nodeValue === undefined) {
-		return { ...node, nodeValue: undefined, explanation }
+		return { ...node, nodeValue: undefined, explanation, missingVariables }
 	}
 	if (!['∕', '×'].includes(node.operator)) {
 		try {
@@ -106,6 +107,7 @@ const evaluate: EvaluationFunction<'operation'> = function (node) {
 			node.operationKind === '+') && {
 			unit: inferUnit(node.operationKind, [node1.unit, node2.unit]),
 		}),
+		missingVariables,
 		nodeValue,
 	}
 }

--- a/packages/core/source/mecanisms/parDéfaut.ts
+++ b/packages/core/source/mecanisms/parDéfaut.ts
@@ -1,5 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode } from '../AST/types'
+import { bonus, mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -27,6 +28,12 @@ const evaluate: EvaluationFunction<'par défaut'> = function (node) {
 		...node,
 		nodeValue: valeur.nodeValue,
 		explanation,
+		missingVariables: mergeMissing(
+			bonus((explanation.valeur as EvaluatedNode).missingVariables),
+			'missingVariables' in explanation.parDéfaut
+				? explanation.parDéfaut.missingVariables
+				: {}
+		),
 		...('unit' in valeur && { unit: valeur.unit }),
 	}
 }

--- a/packages/core/source/mecanisms/plafond.ts
+++ b/packages/core/source/mecanisms/plafond.ts
@@ -1,6 +1,7 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { warning } from '../error'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -48,6 +49,7 @@ const evaluate: EvaluationFunction<'plafond'> = function (node) {
 		nodeValue,
 		...('unit' in valeur && { unit: valeur.unit }),
 		explanation: { valeur, plafond },
+		missingVariables: mergeAllMissing([valeur, plafond]),
 	}
 }
 

--- a/packages/core/source/mecanisms/plancher.ts
+++ b/packages/core/source/mecanisms/plancher.ts
@@ -1,6 +1,7 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { warning } from '../error'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -46,6 +47,7 @@ const evaluate: EvaluationFunction<'plancher'> = function (node) {
 		nodeValue,
 		...('unit' in valeur && { unit: valeur.unit }),
 		explanation: { valeur, plancher },
+		missingVariables: mergeAllMissing([valeur, plancher]),
 	}
 }
 

--- a/packages/core/source/mecanisms/product.ts
+++ b/packages/core/source/mecanisms/product.ts
@@ -1,7 +1,7 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { warning } from '../error'
-import { defaultNode, parseObject } from '../evaluation'
+import { defaultNode, mergeAllMissing, parseObject } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit, simplifyNodeUnit } from '../nodeUnits'
 import { areUnitConvertible, convertUnit, inferUnit } from '../units'
@@ -88,6 +88,7 @@ const evaluateProduit: EvaluationFunction<'produit'> = function (node) {
 			plafond,
 			plafondActif: (assiette.nodeValue as any) > (plafond as any).nodeValue,
 		},
+		missingVariables: mergeAllMissing([assiette, taux, facteur, plafond]),
 	})
 }
 

--- a/packages/core/source/mecanisms/recalcul.ts
+++ b/packages/core/source/mecanisms/recalcul.ts
@@ -83,6 +83,7 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 			parsedSituation: engine.parsedSituation,
 			subEngineId: engine.subEngineId as number,
 		},
+		missingVariables: evaluatedNode.missingVariables,
 		...('unit' in evaluatedNode && { unit: evaluatedNode.unit }),
 	}
 }

--- a/packages/core/source/mecanisms/résoudre-référence-circulaire.ts
+++ b/packages/core/source/mecanisms/résoudre-référence-circulaire.ts
@@ -88,6 +88,7 @@ export const evaluateRésoudreRéférenceCirculaire: EvaluationFunction<'résoud
 				valeur,
 				inversionNumberOfIterations,
 			},
+			missingVariables: valeur.missingVariables,
 		}
 	}
 

--- a/packages/core/source/mecanisms/situation.ts
+++ b/packages/core/source/mecanisms/situation.ts
@@ -1,4 +1,5 @@
 import { ASTNode, EvaluatedNode, isNotYetDefined } from '../AST/types'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -39,10 +40,21 @@ registerEvaluationFunction(parseSituation.nom, function evaluate(node) {
 	const unit =
 		valeur.unit ??
 		('unit' in explanation.valeur ? explanation.valeur.unit : undefined)
+	const missingVariables = mergeAllMissing(
+		[explanation.situationValeur, explanation.valeur].filter(
+			Boolean
+		) as Array<EvaluatedNode>
+	)
+
 	return {
 		...node,
 		nodeValue: valeur.nodeValue,
 		...(unit !== undefined && { unit }),
 		explanation,
+		missingVariables:
+			Object.keys(missingVariables).length === 0 &&
+			isNotYetDefined(valeur.nodeValue)
+				? { [situationKey]: 1 }
+				: missingVariables,
 	}
 })

--- a/packages/core/source/mecanisms/synchronisation.ts
+++ b/packages/core/source/mecanisms/synchronisation.ts
@@ -18,7 +18,15 @@ const evaluate: EvaluationFunction<'synchronisation'> = function (node: any) {
 	const nodeValue = path(data.nodeValue) ?? undefined
 
 	const explanation = { ...node.explanation, data }
-	return { ...node, nodeValue, explanation }
+	return {
+		...node,
+		nodeValue,
+		explanation,
+		missingVariables: {
+			...data.missingVariables,
+			...(data.nodeValue === undefined ? { [data.dottedName]: 1 } : {}),
+		},
+	}
 }
 
 export const mecanismSynchronisation = (v, context) => {

--- a/packages/core/source/mecanisms/tauxProgressif.ts
+++ b/packages/core/source/mecanisms/tauxProgressif.ts
@@ -1,6 +1,6 @@
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
-import { defaultNode } from '../evaluation'
+import { defaultNode, mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -59,12 +59,14 @@ const evaluate: EvaluationFunction<'taux progressif'> = function (node) {
 		(lastTranche.isActive && lastTranche.plafond.nodeValue === Infinity)
 	) {
 		const taux = convertNodeToUnit(parseUnit('%'), evaluate(lastTranche.taux))
-		const { nodeValue } = taux
+		const { nodeValue, missingVariables } = taux
 		lastTranche.taux = taux
 		lastTranche.nodeValue = nodeValue
+		lastTranche.missingVariables = missingVariables
 		return {
 			...evaluatedNode,
 			nodeValue,
+			missingVariables,
 		}
 	}
 
@@ -75,6 +77,7 @@ const evaluate: EvaluationFunction<'taux progressif'> = function (node) {
 		return {
 			...evaluatedNode,
 			nodeValue: undefined,
+			missingVariables: mergeAllMissing(tranches),
 		}
 	}
 
@@ -104,6 +107,7 @@ const evaluate: EvaluationFunction<'taux progressif'> = function (node) {
 		return {
 			...evaluatedNode,
 			nodeValue: undefined,
+			missingVariables: mergeAllMissing(calculationValues),
 		}
 	}
 
@@ -117,6 +121,7 @@ const evaluate: EvaluationFunction<'taux progressif'> = function (node) {
 	return {
 		...evaluatedNode,
 		nodeValue,
+		missingVariables: {},
 	}
 }
 

--- a/packages/core/source/mecanisms/texte.ts
+++ b/packages/core/source/mecanisms/texte.ts
@@ -1,4 +1,5 @@
 import { ASTNode, formatValue } from '..'
+import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
 
@@ -34,6 +35,11 @@ registerEvaluationFunction(NAME, function evaluate(node) {
 	return {
 		...node,
 		explanation,
+		missingVariables: mergeAllMissing(
+			node.explanation.filter(
+				(element) => typeof element !== 'string'
+			) as Array<ASTNode>
+		),
 		nodeValue: explanation
 			.map((element) =>
 				typeof element === 'string' ? element : formatValue(element)

--- a/packages/core/source/mecanisms/trancheUtils.ts
+++ b/packages/core/source/mecanisms/trancheUtils.ts
@@ -1,6 +1,7 @@
 import Engine from '..'
 import { ASTNode, Evaluation } from '../AST/types'
 import { evaluationError, warning } from '../error'
+import { mergeAllMissing } from '../evaluation'
 import parse from '../parse'
 import { convertUnit, inferUnit } from '../units'
 
@@ -89,6 +90,7 @@ export function evaluatePlafondUntilActiveTranche(
 							nodeValue: undefined,
 							isActive: undefined,
 							isAfterActive,
+							missingVariables: mergeAllMissing(calculationValues),
 						},
 					],
 					false,

--- a/packages/core/source/mecanisms/unité.ts
+++ b/packages/core/source/mecanisms/unité.ts
@@ -48,5 +48,6 @@ registerEvaluationFunction(parseUnité.nom, function evaluate(node) {
 		...node,
 		nodeValue,
 		explanation: valeur,
+		missingVariables: valeur.missingVariables,
 	}
 })

--- a/packages/core/source/mecanisms/variations.ts
+++ b/packages/core/source/mecanisms/variations.ts
@@ -1,7 +1,7 @@
 import { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode, Unit } from '../AST/types'
 import { warning } from '../error'
-import { defaultNode } from '../evaluation'
+import { defaultNode, mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
 import parse from '../parse'
@@ -137,6 +137,13 @@ const evaluate: EvaluationFunction<'variations'> = function (node) {
 		nodeValue,
 		...(unit !== undefined && { unit }),
 		explanation,
+		missingVariables: mergeAllMissing(
+			explanation.reduce<ASTNode[]>(
+				(values, { condition, satisfied, consequence }) =>
+					[...values, condition, ...(satisfied ? [consequence] : [])] as any,
+				[]
+			)
+		),
 	}
 }
 

--- a/packages/core/source/parsePublicodes.ts
+++ b/packages/core/source/parsePublicodes.ts
@@ -332,37 +332,3 @@ function inferRulesUnit(parsedRules, rulesDependencies) {
 
 	return cache
 }
-
-// To calculate the “missing variables” of an expression we need to determine
-// the static subset of the rules that are expected in the situation. Theses
-// rules are :
-// - the rules without formulas
-// - the rules with a default formula
-// - the rules with a “fake formula” of "une possibilité"
-//
-// TODO: Simplify this logic. It isn't well thought but is mostly a product of
-// historical evolutions.
-export function getVariablesExpectedInSituation<N extends string>(
-	parsedRules: ParsedRules<N>
-): Array<N> {
-	return Object.entries<RuleNode>(parsedRules)
-		.filter(([, { rawNode }]) => {
-			return (
-				([
-					'formule',
-					'valeur',
-					'somme',
-					'produit',
-					'barème',
-					'grille',
-					'variations',
-					'une de ces conditions',
-					'toutes ces conditions',
-				].every((mecanismName) => !(mecanismName in rawNode)) &&
-					rawNode.type !== 'texte') ||
-				(typeof rawNode.formule === 'object' &&
-					'une possibilité' in rawNode.formule)
-			)
-		})
-		.map(([dottedName]) => dottedName as N)
-}


### PR DESCRIPTION
Avec l'introduction des variables traversées dans #189, j'avais également modifié l'implémentation des variables manquantes afin de la dériver des variables traversées.

C'était un changement cassant mais l'adaptation des tests unitaires étant facile j'ai cru de manière un peu candide qu'il n'y aurait pas trop d'effets de bords pour mon-entreprise (et sans doute nosgestesclimat). En pratique c'est vraiment plus compliqué que ça à remplacer, je préfère donc revert le changement.

Le paquet expose donc les variables traversées (calculées de manière générique à l'extérieure des mécanismes) et les variables manquantes (calculées à l'intérieur de chaque mécanisme).