### PR TITLE
Retour api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.0-beta.41
+
+**api**
+
+-   Remplace le paramètre du middleware par un Engine (remplace `publicodesAPI(() => new Engine(rule))` par `publicodesAPI(new Engine(rule))`)
+-   Les expressions acceptent des objets ou des tableaux d'objets
+
 ## 1.0.0-beta.40
 
 **core**

--- a/packages/api/example.ts
+++ b/packages/api/example.ts
@@ -14,7 +14,19 @@ const router = new Router<State, Context>()
 app.use(cors())
 
 // Create middleware with your Engine
-const apiRoutes = publicodesAPI(() => new Engine(`coucou: 0`))
+const apiRoutes = publicodesAPI(new Engine(`
+prix:
+prix . carottes: 2€/kg
+prix . champignons: 5€/kg
+prix . avocat: 2€/avocat
+
+dépenses primeur:
+  formule:
+    somme:
+      - prix . carottes * 1.5 kg
+      - prix . champignons * 500g
+      - prix . avocat * 3 avocat
+`))
 
 // Basic routes usage (/evaluate, /rules, etc.)
 router.use(apiRoutes)

--- a/packages/api/example.ts
+++ b/packages/api/example.ts
@@ -14,7 +14,8 @@ const router = new Router<State, Context>()
 app.use(cors())
 
 // Create middleware with your Engine
-const apiRoutes = publicodesAPI(new Engine(`
+const apiRoutes = publicodesAPI(
+	new Engine(`
 prix:
 prix . carottes: 2€/kg
 prix . champignons: 5€/kg
@@ -26,7 +27,8 @@ dépenses primeur:
       - prix . carottes * 1.5 kg
       - prix . champignons * 500g
       - prix . avocat * 3 avocat
-`))
+`)
+)
 
 // Basic routes usage (/evaluate, /rules, etc.)
 router.use(apiRoutes)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.40",
+	"version": "1.0.0-beta.41",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,11 +22,11 @@
 		"prepack": "yarn workspace publicodes run prepack && yarn run build",
 		"build": "run build:openapi && run build:tsup",
 		"build:watch": "run build:openapi:watch & run wait:openapi && run build:tsup:watch",
-		"build:tsup": "tsup-node",
+		"build:tsup": "tsup-node --shims",
 		"build:tsup:watch": "run build:tsup --watch",
 		"copy:openapi": "cp ./source/openapi.json ./dist",
 		"wait:openapi": "wait-on ./source/openapi.json",
-		"build:openapi": "swagger-cli bundle ./source/openapi.yaml > ./source/openapi.json",
+		"build:openapi": "swagger-cli bundle ./source/openapi.yaml -o ./source/openapi.json",
 		"build:openapi:watch": "nodemon -d 500ms -w ./source/openapi.yaml -x \"yarn build:openapi\"",
 		"clean": "rm -rf ./dist ./source/openapi.json"
 	},
@@ -51,21 +51,21 @@
 		"openapi-validator-middleware": "^3.2.6"
 	},
 	"peerDependencies": {
-		"publicodes": "^1.0.0-beta.35"
+		"publicodes": "^1.0.0-beta.40"
 	},
 	"devDependencies": {
 		"@apidevtools/swagger-cli": "^4.0.4",
 		"@types/koa": "^2.13.4",
 		"@types/koa__cors": "^3.3.0",
 		"@types/koa__router": "^8.0.11",
-		"@types/node": "^17.0.29",
+		"@types/node": "^17.0.35",
 		"chai-http": "^4.3.0",
-		"nodemon": "^2.0.15",
-		"publicodes": "^1.0.0-beta.35",
-		"ts-node": "^10.7.0",
-		"tsup": "^5.12.8",
-		"typescript": "4.7.1-rc",
-		"vitest": "^0.12.3",
+		"nodemon": "^2.0.16",
+		"publicodes": "^1.0.0-beta.40",
+		"ts-node": "^10.8.0",
+		"tsup": "^6.0.1",
+		"typescript": "^4.7.2",
+		"vitest": "^0.12.9",
 		"wait-on": "^6.0.1"
 	}
 }

--- a/packages/api/source/index.ts
+++ b/packages/api/source/index.ts
@@ -1,8 +1,7 @@
 import path from 'path'
-import type { default as openapiType } from './openapi.json'
+import openapiJson from './openapi.json' assert { type: 'json' }
 
 export { koaMiddleware } from './middleware/index.js'
 
 export const openapiPath = path.resolve(__dirname, `openapi.json`)
-
-export const openapi = { ...require('./openapi.json') } as typeof openapiType
+export const openapi = openapiJson

--- a/packages/api/source/middleware/koa.ts
+++ b/packages/api/source/middleware/koa.ts
@@ -5,7 +5,7 @@ import koaBody from 'koa-body'
 import OAPIValidator from 'openapi-validator-middleware'
 import { openapiPath } from '../index.js'
 import * as routes from '../route/index.js'
-import { Expressions, NewEngine, Situation } from '../types.js'
+import { Engine, Expressions, Situation } from '../types.js'
 
 const InputValidationError = OAPIValidator.InputValidationError
 
@@ -39,7 +39,7 @@ interface Context extends ParameterizedContext {
 	req: CustomIncomingMessage
 }
 
-export default function publicodesAPI(newEngine: NewEngine) {
+export default function publicodesAPI(engine: Engine) {
 	const router = new Router()
 
 	// The validator uses the original openapi.json, not the custom one
@@ -94,7 +94,7 @@ export default function publicodesAPI(newEngine: NewEngine) {
 				const { situation, expressions } = ctx.request.body as EvaluateBody
 
 				if (expressions) {
-					const evaluateResult = routes.evaluate(newEngine, {
+					const evaluateResult = routes.evaluate(engine, {
 						expressions,
 						situation,
 					})
@@ -106,7 +106,7 @@ export default function publicodesAPI(newEngine: NewEngine) {
 		)
 		.get('/rules', validateInput('/rules'), (ctx: Context) => {
 			ctx.type = 'application/json'
-			ctx.body = routes.rules(newEngine)
+			ctx.body = routes.rules(engine)
 		})
 		.get(
 			'/rules/:rule',
@@ -115,7 +115,7 @@ export default function publicodesAPI(newEngine: NewEngine) {
 				const { rule } = ctx.params
 
 				ctx.type = 'application/json'
-				ctx.body = routes.rulesId(newEngine, rule)
+				ctx.body = routes.rulesId(engine, rule)
 			}
 		)
 

--- a/packages/api/source/openapi.yaml
+++ b/packages/api/source/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: Publicode API
-  version: 1.0.0-beta.40
+  version: 1.0.0-beta.41
   description: Cet API expose vos règles Publicodes.
 
 components:

--- a/packages/api/source/openapi.yaml
+++ b/packages/api/source/openapi.yaml
@@ -12,9 +12,12 @@ components:
       oneOf:
         - type: array
           items:
-            type: string
+            oneOf:
+              - type: string
+              - type: object
           minItems: 1
         - type: string
+        - type: object
 
     Situation:
       description: La situation avec laquelle l'expression ou les expressions seront évaluées

--- a/packages/api/source/route/evaluate.ts
+++ b/packages/api/source/route/evaluate.ts
@@ -1,4 +1,4 @@
-import { Expressions, NewEngine, Situation } from '../types.js'
+import { Expressions, Engine, Situation } from '../types.js'
 import { catchError, PickInObject } from '../utils.js'
 
 export interface EvaluateBody {
@@ -7,10 +7,10 @@ export interface EvaluateBody {
 }
 
 export function evaluate(
-	newEngine: NewEngine,
+	originalEngine: Engine,
 	{ expressions, situation }: EvaluateBody
 ) {
-	const engine = newEngine(expressions, situation)
+	const engine = originalEngine.shallowCopy()
 	const [error] = catchError(() => engine.setSituation(situation))
 
 	const keysKept = [

--- a/packages/api/source/route/rules.ts
+++ b/packages/api/source/route/rules.ts
@@ -1,9 +1,7 @@
-import { NewEngine } from '../types.js'
+import { Engine } from '../types.js'
 import { catchError, PickInObject } from '../utils.js'
 
-export function rules(newEngine: NewEngine) {
-	const engine = newEngine({})
-
+export function rules(engine: Engine) {
 	const rules = engine.getParsedRules()
 
 	const filteredRules = Object.fromEntries(
@@ -24,9 +22,7 @@ export function rules(newEngine: NewEngine) {
 
 type RulesId = string
 
-export function rulesId(newEngine: NewEngine, id: RulesId) {
-	const engine = newEngine({})
-
+export function rulesId(engine: Engine, id: RulesId) {
 	const [error, result] = catchError(() => engine.getRule(id))
 
 	return !error

--- a/packages/api/source/route/test/evaluate.test.ts
+++ b/packages/api/source/route/test/evaluate.test.ts
@@ -1,6 +1,6 @@
-import { Expressions, NewEngine, Situation } from '../../types'
 import Engine from 'publicodes'
 import { describe, expect, it, vi } from 'vitest'
+import { Expressions, Situation } from '../../types'
 import { evaluate } from '../evaluate'
 
 const obj = {
@@ -11,10 +11,10 @@ const obj = {
 		traversedVariables: 42,
 		missingVariables: 42,
 	}),
+	shallowCopy: () => obj,
 }
 
-const mockedNewEngine = ((_expressions: Expressions, _situation?: Situation) =>
-	obj) as unknown as NewEngine
+const mockedEngine = obj as unknown as Engine
 
 const rules = `
 prix:
@@ -30,7 +30,7 @@ dépenses primeur:
       - prix . avocat * 3 avocat
 `
 
-const newEngine = () => new Engine(rules)
+const engine = new Engine(rules)
 
 describe('evaluate', () => {
 	it('Test input/output', () => {
@@ -38,7 +38,7 @@ describe('evaluate', () => {
 		const spyEval = vi.spyOn(obj, 'evaluate')
 
 		expect(
-			evaluate(mockedNewEngine, {
+			evaluate(mockedEngine, {
 				expressions: 'expressions',
 				situation: { test: 'test' },
 			})
@@ -61,13 +61,13 @@ describe('evaluate', () => {
 	})
 
 	it('One expression in array should return same result as a single same expression', () => {
-		expect(
-			evaluate(mockedNewEngine, { expressions: ['coucou'] })
-		).toMatchObject(evaluate(mockedNewEngine, { expressions: 'coucou' }))
+		expect(evaluate(mockedEngine, { expressions: ['coucou'] })).toMatchObject(
+			evaluate(mockedEngine, { expressions: 'coucou' })
+		)
 	})
 
 	it('Simple test with real Engine', () => {
-		expect(evaluate(newEngine, { expressions: ['21 + 21', '6 * 7'] }))
+		expect(evaluate(engine, { expressions: ['21 + 21', '6 * 7'] }))
 			.toMatchInlineSnapshot(`
 				{
 				  "evaluate": [
@@ -91,7 +91,7 @@ describe('evaluate', () => {
 
 	it('Test with real Engine', () => {
 		expect(
-			evaluate(newEngine, {
+			evaluate(engine, {
 				expressions: ['dépenses primeur', 'prix', 'prix . avocat * 21'],
 			})
 		).toMatchInlineSnapshot(`
@@ -146,7 +146,7 @@ describe('evaluate', () => {
 
 	it('Test invalid syntax in situation', () => {
 		expect(
-			evaluate(newEngine, {
+			evaluate(engine, {
 				expressions: ['1 + 1'],
 				situation: { test: '"42' },
 			})
@@ -154,12 +154,12 @@ describe('evaluate', () => {
 	})
 
 	it('Test syntax error in expression', () => {
-		expect(evaluate(newEngine, { expressions: '1+1' })).toMatchSnapshot()
+		expect(evaluate(engine, { expressions: '1+1' })).toMatchSnapshot()
 	})
 
 	it('Test two syntax error in expression', () => {
 		expect(
-			evaluate(newEngine, {
+			evaluate(engine, {
 				expressions: ['1+1', '"42', '42'],
 			})
 		).toMatchSnapshot()
@@ -167,12 +167,12 @@ describe('evaluate', () => {
 
 	it('Test error in expression and situation at same time', () => {
 		expect(
-			evaluate(newEngine, { expressions: '1+1', situation: { test: '"42' } })
+			evaluate(engine, { expressions: '1+1', situation: { test: '"42' } })
 		).toMatchSnapshot()
 	})
 
 	it('Test no expressions', () => {
-		expect(evaluate(newEngine, { expressions: [] })).toMatchInlineSnapshot(`
+		expect(evaluate(engine, { expressions: [] })).toMatchInlineSnapshot(`
 			{
 			  "evaluate": [],
 			  "situationError": null,

--- a/packages/api/source/route/test/rules.test.ts
+++ b/packages/api/source/route/test/rules.test.ts
@@ -2,11 +2,11 @@ import Engine from 'publicodes'
 import { describe, expect, it } from 'vitest'
 import { rules, rulesId } from '../rules'
 
-const newEngine = () => new Engine('rules: 42')
+const engine = new Engine('rules: 42')
 
 describe('evaluate', () => {
 	it('Should list rules', () => {
-		expect(rules(newEngine)).toMatchInlineSnapshot(`
+		expect(rules(engine)).toMatchInlineSnapshot(`
 			{
 			  "rules": {
 			    "nodeKind": "rule",
@@ -23,7 +23,7 @@ describe('evaluate', () => {
 	})
 
 	it('Should return rules data', () => {
-		expect(rulesId(newEngine, 'rules')).toMatchInlineSnapshot(`
+		expect(rulesId(engine, 'rules')).toMatchInlineSnapshot(`
 			{
 			  "nodeKind": "rule",
 			  "rawNode": {
@@ -38,7 +38,7 @@ describe('evaluate', () => {
 	})
 
 	it('Should return an error', () => {
-		expect(rulesId(newEngine, 'bad rules')).toMatchInlineSnapshot(`
+		expect(rulesId(engine, 'bad rules')).toMatchInlineSnapshot(`
 			{
 			  "error": {
 			    "message": "La règle 'bad rules' n'existe pas",

--- a/packages/api/source/test-e2e/__snapshots__/index.test.ts.snap
+++ b/packages/api/source/test-e2e/__snapshots__/index.test.ts.snap
@@ -142,6 +142,15 @@ exports[`e2e koa middleware > Test evaluate endpoint with empty expression 2`] =
   },
   {
     "dataPath": ".expressions",
+    "keyword": "type",
+    "message": "should be object",
+    "params": {
+      "type": "object",
+    },
+    "schemaPath": "#/properties/expressions/oneOf/2/type",
+  },
+  {
+    "dataPath": ".expressions",
     "keyword": "oneOf",
     "message": "should match exactly one schema in oneOf",
     "params": {
@@ -171,6 +180,15 @@ exports[`e2e koa middleware > Test evaluate endpoint with null expression 2`] = 
       "type": "string",
     },
     "schemaPath": "#/properties/expressions/oneOf/1/type",
+  },
+  {
+    "dataPath": ".expressions",
+    "keyword": "type",
+    "message": "should be object",
+    "params": {
+      "type": "object",
+    },
+    "schemaPath": "#/properties/expressions/oneOf/2/type",
   },
   {
     "dataPath": ".expressions",

--- a/packages/api/source/test-e2e/index.test.ts
+++ b/packages/api/source/test-e2e/index.test.ts
@@ -13,8 +13,7 @@ const app = new Koa<State, Context>()
 const router = new Router<State, Context>()
 
 const apiRoutes = publicodesAPI(
-	() =>
-		new Engine(`
+	new Engine(`
 coucou: 0
 coucou . j'ai des caractères spéciaux: "'ok'"
 `)

--- a/packages/api/source/types.ts
+++ b/packages/api/source/types.ts
@@ -1,11 +1,8 @@
-import type Engine from 'publicodes'
+import type PublicodesEngine from 'publicodes'
 import type { PublicodesExpression } from 'publicodes'
 
 export type Expressions = PublicodesExpression | PublicodesExpression[]
 
 export type Situation = Partial<Record<string, PublicodesExpression>>
 
-export type NewEngine = (
-	expressions: Expressions,
-	situation?: Situation
-) => Engine
+export type Engine = PublicodesEngine

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,7 +3,7 @@
 		/* Basic Options */
 		// "incremental": true, // disabled for tsup, see https://github.com/egoist/tsup/issues/615 for implementation status
 		"target": "ES2020",
-		"module": "Node16",
+		"module": "NodeNext",
 		"outDir": "dist",
 		"declaration": true,
 
@@ -24,7 +24,7 @@
 		"noFallthroughCasesInSwitch": true,
 
 		/* Module Resolution Options */
-		"moduleResolution": "Node16",
+		"moduleResolution": "NodeNext",
 		"isolatedModules": true,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,

--- a/packages/api/tsup.config.ts
+++ b/packages/api/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig([
 	{
 		entry: ['source/index.ts'],
 		format: ['cjs', 'esm'],
-		target: 'es2020',
+		target: 'ES2020',
 		clean: true,
 		dts: true,
 		onSuccess: 'yarn copy:openapi',

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -1,3 +1,7 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({})
+export default defineConfig({
+	esbuild: {
+		target: 'ES2020',
+	},
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.40",
+	"version": "1.0.0-beta.41",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.40",
+	"version": "1.0.0-beta.41",
 	"description": "UI to explore publicodes computations",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/website/src/pages/api-rest.mdx
+++ b/website/src/pages/api-rest.mdx
@@ -16,7 +16,7 @@ qui expose des points d'entrée analogues à l'interpréteur Publicodes :
 
 - `POST` `/evaluate` Évalue une ou plusieurs expressions avec une situation donnée
   - Les paramètres sont envoyés au format JSON :
-  - `expressions` de type `string` ou `string[]`, ex: `["dépenses primeur"]`
+  - `expressions` de type `string`, `object`, `string[]` ou `object[]`, ex: `["dépenses primeur"]`
   - `situation` un objet de `clé : valeur`, ex: `{ "prix . carottes" : "1€/kg" }`
 - `GET` `/rules` Retourne la liste de toutes vos règles
 - `GET` `/rules/{rule}` Retourne une règle spécifique

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
 "@docsearch/css@npm:3.0.0":
   version: 3.0.0
   resolution: "@docsearch/css@npm:3.0.0"
@@ -2683,6 +2692,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:^0.3.0":
   version: 0.3.4
   resolution: "@jridgewell/trace-mapping@npm:0.3.4"
@@ -2855,20 +2874,20 @@ __metadata:
     "@types/koa": ^2.13.4
     "@types/koa__cors": ^3.3.0
     "@types/koa__router": ^8.0.11
-    "@types/node": ^17.0.29
+    "@types/node": ^17.0.35
     chai-http: ^4.3.0
     koa: ^2.13.4
     koa-body: ^5.0.0
-    nodemon: ^2.0.15
+    nodemon: ^2.0.16
     openapi-validator-middleware: ^3.2.6
-    publicodes: ^1.0.0-beta.35
-    ts-node: ^10.7.0
-    tsup: ^5.12.8
-    typescript: 4.7.1-rc
-    vitest: ^0.12.3
+    publicodes: ^1.0.0-beta.40
+    ts-node: ^10.8.0
+    tsup: ^6.0.1
+    typescript: ^4.7.2
+    vitest: ^0.12.9
     wait-on: ^6.0.1
   peerDependencies:
-    publicodes: ^1.0.0-beta.35
+    publicodes: ^1.0.0-beta.40
   languageName: unknown
   linkType: soft
 
@@ -3672,10 +3691,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^17.0.29":
-  version: 17.0.29
-  resolution: "@types/node@npm:17.0.29"
-  checksum: bb9d7bce9d6d3882efd9d63b773b548dce98df4bd57eff8ceaa316aa2f3346e36d3618764cc93da84bbff92005174a35eec3465cde91ee973ef1c351ffa40074
+"@types/node@npm:^17.0.35":
+  version: 17.0.35
+  resolution: "@types/node@npm:17.0.35"
+  checksum: 7a24946ae7fd20267ed92466384f594e448bfb151081158d565cc635d406ecb29ea8fb85fcd2a1f71efccf26fb5bd3c6f509bde56077eb8b832b847a6664bc62
   languageName: node
   linkType: hard
 
@@ -6439,7 +6458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.2":
+"debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -11405,9 +11424,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemon@npm:^2.0.15":
-  version: 2.0.15
-  resolution: "nodemon@npm:2.0.15"
+"nodemon@npm:^2.0.16":
+  version: 2.0.16
+  resolution: "nodemon@npm:2.0.16"
   dependencies:
     chokidar: ^3.5.2
     debug: ^3.2.7
@@ -11421,7 +11440,7 @@ __metadata:
     update-notifier: ^5.1.0
   bin:
     nodemon: bin/nodemon.js
-  checksum: 0569b09b713fdcc76f06734d7cc106950e69e02069cbf44bda3fae8d266926bdfa003aeddd22f8fcdf46ea6ff51ca64f5528f8006536e79820a26e648ef346cf
+  checksum: ff818aa91b283bd0f1f6cfb8fdc9b5c3e74d5efa0cb72276dc242b742dc35d3f0720d35d99dbe85ecf6df7185f083ef9b1f7908094e43fd4e2508b6805d644dc
   languageName: node
   linkType: hard
 
@@ -13042,7 +13061,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"publicodes@^1.0.0-beta.35, publicodes@workspace:packages/core":
+"publicodes@^1.0.0-beta.35, publicodes@^1.0.0-beta.40, publicodes@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "publicodes@workspace:packages/core"
   dependencies:
@@ -14064,6 +14083,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: ecd7917deeaa3005ac7cdd64186daf024594bd9ba940e32fc8966602a83349074d0ec999256009dc4475e7c3786ac52cdd824ee9df514b8c356b960fda6bfb34
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^2.74.1":
+  version: 2.74.1
+  resolution: "rollup@npm:2.74.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: c34dc78317aa0a153010061e5954225b3e18f4013feb9c0476f6878dc3485ac765c28b7849441e4a2ab69c337892bc66399fb7d4b239b94f4758adfdb1f99440
   languageName: node
   linkType: hard
 
@@ -15392,6 +15425,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.8.0":
+  version: 10.8.0
+  resolution: "ts-node@npm:10.8.0"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 1c22dc8dd80d0ba4dd4250b82cc032b63f6fbe8c87f8197cef43e7f9e2d43f5b333b445ed712e3006e24119257b4bff2c46605f7da61ab6f5e9514885d296f0c
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.1":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
@@ -15436,9 +15507,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^5.12.8":
-  version: 5.12.8
-  resolution: "tsup@npm:5.12.8"
+"tsup@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "tsup@npm:6.0.1"
   dependencies:
     bundle-require: ^3.0.2
     cac: ^6.7.12
@@ -15450,19 +15521,25 @@ __metadata:
     joycon: ^3.0.1
     postcss-load-config: ^3.0.1
     resolve-from: ^5.0.0
-    rollup: ^2.60.0
+    rollup: ^2.74.1
     source-map: 0.8.0-beta.0
     sucrase: ^3.20.3
     tree-kill: ^1.2.2
   peerDependencies:
+    "@swc/core": ^1
+    postcss: ^8.4.12
     typescript: ^4.1.0
   peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
     typescript:
       optional: true
   bin:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
-  checksum: 52629d44e3804a51e2136b37d9cc725d736007aaf19ef4795b1c3f8ede5a786386e6e4f4dcfb5e8e00496b014ed767352d1b77a2d48dd8f72a064b94617934e5
+  checksum: 4630409533213b3b1953204b29fad514bd93bdb8635b18c12f76101d0dae745982ab7fe47be052111c3b99e23ef356eebce19e77ebd9f72d3769fda43cf9af6f
   languageName: node
   linkType: hard
 
@@ -15513,16 +15590,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.7.1-rc":
-  version: 4.7.1-rc
-  resolution: "typescript@npm:4.7.1-rc"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: c340f341cb974310b20c49ff52419cd0041e9591d0e25c127d1f8796300b72cf89484448128dfac13f49346b8b56ce257f4e75165b9f941b43d11936849de15c
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^4.5.5":
   version: 4.5.5
   resolution: "typescript@npm:4.5.5"
@@ -15533,13 +15600,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.7.1-rc#~builtin<compat/typescript>":
-  version: 4.7.1-rc
-  resolution: "typescript@patch:typescript@npm%3A4.7.1-rc#~builtin<compat/typescript>::version=4.7.1-rc&hash=bda367"
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 76f6f2e270199a2d239204c9f3d866f9817c83da1d870f15a6657437d2ec5f5411f987508effd02a38f438b443c2967c10d06514150911a8bcba4bc53c8630ca
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
   languageName: node
   linkType: hard
 
@@ -15550,6 +15617,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=bda367"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 09d93fc0983d38eadd9b0427f790b49b4437f45002a87d447be3fbe53120880e87a91dd03e1d900498f99205d6e0b7c9784fe41fca11d56f4bbce371f74bb160
   languageName: node
   linkType: hard
 
@@ -16066,7 +16143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"v8-compile-cache-lib@npm:^3.0.0":
+"v8-compile-cache-lib@npm:^3.0.0, v8-compile-cache-lib@npm:^3.0.1":
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
@@ -16181,13 +16258,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^0.12.3":
-  version: 0.12.3
-  resolution: "vitest@npm:0.12.3"
+"vitest@npm:^0.12.9":
+  version: 0.12.9
+  resolution: "vitest@npm:0.12.9"
   dependencies:
     "@types/chai": ^4.3.1
     "@types/chai-subset": ^1.3.3
     chai: ^4.3.6
+    debug: ^4.3.4
     local-pkg: ^0.4.1
     tinypool: ^0.1.3
     tinyspy: ^0.3.2
@@ -16208,7 +16286,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 78e8d5e14e349c53b3e31a1ae7416175cda08d87ed44d4a25f906ea3a04488355dd650cf7a836a9150f418ccaaaf8fa90d7eb88cce606ca08664459c6b029a62
+  checksum: efc1c7279273ec594e8a1865c6bc38e758f87e500e2daf971f110b3f845d0d2552813e80b8d9634cca9a10fe626b5a9eb8f5533d9a97e50d7277c3e969cab433
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
-   Remplace le paramètre du middleware par un Engine (remplace `publicodesAPI(() => new Engine(rule))` par `publicodesAPI(new Engine(rule))`)
-   Les expressions acceptent des objets ou des tableaux d'objets
- Update to beta 41