### PR TITLE
No yaml dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,12 +38,12 @@
 		"sinon-chai": "^3.7.0",
 		"ts-node": "^10.7.0",
 		"tsup": "^6.0.1",
-		"typescript": "^4.5.5"
+		"typescript": "^4.5.5",
+		"yaml": "^1.9.2"
 	},
 	"dependencies": {
 		"moo": "^0.5.1",
-		"nearley": "^2.19.2",
-		"yaml": "^1.9.2"
+		"nearley": "^2.19.2"
 	},
 	"scripts": {
 		"build:grammar": "nearleyc ./source/grammar.ne -o ./source/grammar.js",

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -115,7 +115,7 @@ export default class Engine<Name extends string = string> {
 	rulesDependencies: ReturnType<typeof parsePublicodes>['rulesDependencies']
 
 	constructor(
-		rules: string | Record<string, Rule> = {},
+		rules: Record<string, Rule> = {},
 		options: Partial<Options> = {}
 	) {
 		this.options = { ...options, logger: options.logger ?? console }

--- a/packages/core/source/parsePublicodes.ts
+++ b/packages/core/source/parsePublicodes.ts
@@ -1,4 +1,3 @@
-import yaml from 'yaml'
 import { ASTNode, Logger, ParsedRules } from '.'
 import { makeASTTransformer, traverseParsedRules } from './AST'
 import parse from './parse'
@@ -27,7 +26,7 @@ type RawRule = Omit<Rule, 'nom'> | string | number
 export type RawPublicodes = Record<string, RawRule>
 
 export default function parsePublicodes<RuleNames extends string>(
-	rawRules: RawPublicodes | string,
+	rawRules: RawPublicodes,
 	partialContext: Partial<Context> = {}
 ): {
 	parsedRules: ParsedRules<RuleNames>
@@ -35,10 +34,7 @@ export default function parsePublicodes<RuleNames extends string>(
 	rulesDependencies: Record<RuleNames, Array<RuleNames>>
 } {
 	// STEP 1: parse Yaml
-	let rules =
-		typeof rawRules === 'string'
-			? (yaml.parse(('' + rawRules).replace(/\t/g, '  ')) as RawPublicodes)
-			: { ...rawRules }
+	let rules = { ...rawRules }
 
 	// STEP 2: transpile [ref] writing
 	rules = transpileRef(rules)

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -2,10 +2,13 @@
 import { expect } from 'chai'
 import dedent from 'dedent-js'
 import Engine from '../source/index'
+import yaml from 'yaml'
+
+const parseYaml = (yamlString) => yaml.parse(dedent(yamlString))
 
 describe('inversions', () => {
 	it('should handle non inverted example', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -23,7 +26,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle simple inversion', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -45,7 +48,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle inversion with value at 0', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -66,7 +69,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle inversions with missing variables', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -113,17 +116,17 @@ describe('inversions', () => {
 	})
 
 	it('should reset cache after a failed inversion', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			net:
-				variations:
-					- si: assiette < 100
-						alors: 100
-					- sinon: 200
+		      variations:
+		        - si: assiette < 100
+		          alors: 100
+		        - sinon: 200
 			assiette: brut
 			brut:
-				inversion numérique:
-					avec:
-						- net
+			  inversion numérique:
+			    avec:
+			      - net
 		`
 
 		const engine = new Engine(rules)
@@ -132,7 +135,7 @@ describe('inversions', () => {
 	})
 
 	it("shouldn't report a missing salary if another salary was input", () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -171,7 +174,7 @@ describe('inversions', () => {
 	})
 
 	it('complex inversion with composantes', () => {
-		const rules = dedent`
+		const rules = parseYaml`
       net:
         formule:
           produit:

--- a/packages/core/test/library.test.js
+++ b/packages/core/test/library.test.js
@@ -1,16 +1,20 @@
 import { expect } from 'chai'
 import Engine from '../source/index'
+import yaml from 'yaml'
+import dedent from 'dedent-js'
+
+const parseYaml = (yamlString) => yaml.parse(yamlString)
 
 describe('library', function () {
 	it('should let the user define its own rule', function () {
-		let rules = `
+		let rules = parseYaml(`
 yo:
   formule: 200
 ya:
   formule:  yo + 1
 yi:
   formule:  yo + 2
-`
+`)
 		let engine = new Engine(rules)
 
 		expect(engine.evaluate('ya').nodeValue).to.equal(201)
@@ -18,15 +22,15 @@ yi:
 	})
 
 	it('should let the user define a simplified revenue tax system', function () {
-		let rules = `
+		let rules = parseYaml(`
 revenu imposable:
   question: Quel est votre revenu imposable ?
   unité: €
 
 revenu abattu:
   formule:
-		valeur: revenu imposable
-		abattement: 10%
+    valeur: revenu imposable
+    abattement: 10%
 
 impôt sur le revenu:
   formule:
@@ -45,11 +49,11 @@ impôt sur le revenu:
 
 impôt sur le revenu à payer:
   formule:
-		valeur: impôt sur le revenu
-		abattement:
-			valeur: 1177 - (75% * impôt sur le revenu)
-			plancher: 0
-`
+    valeur: impôt sur le revenu
+    abattement:
+      valeur: 1177 - (75% * impôt sur le revenu)
+      plancher: 0
+`)
 
 		let engine = new Engine(rules)
 		engine.setSituation({
@@ -71,23 +75,23 @@ impôt sur le revenu à payer:
 	})
 
 	it('should let the user reference rules in the situation', function () {
-		let rules = `
+		let rules = parseYaml(`
 referenced in situation:
   formule: 200
-overwrited in situation:
+overwritten in situation:
   formule: 100
 result:
-  formule: overwrited in situation + 22
-`
+  formule: overwritten in situation + 22
+`)
 		let engine = new Engine(rules)
 		engine.setSituation({
-			'overwrited in situation': 'referenced in situation',
+			'overwritten in situation': 'referenced in situation',
 		})
 		expect(engine.evaluate('result').nodeValue).to.equal(222)
 	})
 })
 
-const co2Rules = `
+const co2Rules = yaml.parse(`
 douche:
   icônes: 🚿
 
@@ -196,4 +200,4 @@ douche . durée de la douche:
     expresse: 5
     moyenne: 10
     lente: 20
-`
+`)


### PR DESCRIPTION
Partial fix to #124

The idea here is to simply remove the yaml parser from the publicode bundle. 

It would be the responsability of the client to transform his object
representation (YAML, JSON) to a Javascript object when initialising the
Engine. 

- [ ] rewrite the other test suites

What do you think ? 

This PR would be a breaking change of course. But as far as I know, very easily corrected by client libraries, that would benefit a lot : 
- for browser side publicode usage, the weight gain is 3/5 (!)
- for server side, the client can use its prefered yaml parser

![image](https://user-images.githubusercontent.com/1177762/178462453-41852f1f-4af2-4220-b340-b66f2196d7ea.png)
