### PR TITLE
No yaml dependency 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-beta.47
+
+**core**
+
+-   **⚠ Changement cassant** Enlève la possibilité d'initialiser l'`Engine` avec un string YAML. Le client doit se charger du parsing lui-même.
+
 ## 1.0.0-beta.46
 
 **publicodes-react**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"clean": "yarn workspaces foreach run clean"
 	},
 	"devDependencies": {
-		"prettier": "^2.5.1"
+		"prettier": "^2.5.1",
+		"yaml": "^2.1.1"
 	},
 	"packageManager": "yarn@3.2.0"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.46",
+	"version": "1.0.0-beta.47",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -51,7 +51,7 @@
 		"openapi-validator-middleware": "^3.2.6"
 	},
 	"peerDependencies": {
-		"publicodes": "^1.0.0-beta.46"
+		"publicodes": "^1.0.0-beta.47"
 	},
 	"devDependencies": {
 		"@apidevtools/swagger-cli": "^4.0.4",
@@ -61,7 +61,7 @@
 		"@types/node": "^17.0.35",
 		"chai-http": "^4.3.0",
 		"nodemon": "^2.0.16",
-		"publicodes": "^1.0.0-beta.46",
+		"publicodes": "^1.0.0-beta.47",
 		"ts-node": "^10.8.0",
 		"tsup": "^6.0.1",
 		"typescript": "^4.7.2",

--- a/packages/api/source/route/test/evaluate.test.ts
+++ b/packages/api/source/route/test/evaluate.test.ts
@@ -2,6 +2,7 @@ import Engine from 'publicodes'
 import { describe, expect, it, vi } from 'vitest'
 import { Expressions, Situation } from '../../types'
 import { evaluate } from '../evaluate'
+import { parse } from 'yaml'
 
 const obj = {
 	setSituation: (_situation?: Situation) => 42,
@@ -30,7 +31,7 @@ dépenses primeur:
       - prix . avocat * 3 avocat
 `
 
-const engine = new Engine(rules)
+const engine = new Engine(parse(rules))
 
 describe('evaluate', () => {
 	it('Test input/output', () => {

--- a/packages/api/source/route/test/rules.test.ts
+++ b/packages/api/source/route/test/rules.test.ts
@@ -2,7 +2,7 @@ import Engine from 'publicodes'
 import { describe, expect, it } from 'vitest'
 import { rules, rulesId } from '../rules'
 
-const engine = new Engine('rules: 42')
+const engine = new Engine({ rules: 42 })
 
 describe('evaluate', () => {
 	it('Should list rules', () => {

--- a/packages/api/source/test-e2e/index.test.ts
+++ b/packages/api/source/test-e2e/index.test.ts
@@ -4,6 +4,7 @@ import Koa from 'koa'
 import Engine from 'publicodes'
 import { afterAll, beforeAll, chai, describe, expect, it } from 'vitest'
 import publicodesAPI from '../middleware/koa'
+import { parse } from 'yaml'
 
 interface State extends Koa.DefaultState {}
 
@@ -13,10 +14,12 @@ const app = new Koa<State, Context>()
 const router = new Router<State, Context>()
 
 const apiRoutes = publicodesAPI(
-	new Engine(`
+	new Engine(
+		parse(`
 coucou: 0
 coucou . j'ai des caractères spéciaux: "'ok'"
 `)
+	)
 )
 
 router.use(apiRoutes)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.46",
+	"version": "1.0.0-beta.47",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,8 +42,7 @@
 	},
 	"dependencies": {
 		"moo": "^0.5.1",
-		"nearley": "^2.19.2",
-		"yaml": "^1.9.2"
+		"nearley": "^2.19.2"
 	},
 	"scripts": {
 		"build:grammar": "nearleyc ./source/grammar.ne -o ./source/grammar.js",

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -101,7 +101,7 @@ export default class Engine<Name extends string = string> {
 	subEngines: Array<Engine<Name>> = []
 	subEngineId: number | undefined
 
-	constructor(rules: RawPublicodes<Name> | string = {}, options: Options = {}) {
+	constructor(rules: RawPublicodes<Name> = {}, options: Options = {}) {
 		const initialContext = {
 			dottedName: '' as const,
 			...options,

--- a/packages/core/source/parsePublicodes.ts
+++ b/packages/core/source/parsePublicodes.ts
@@ -71,7 +71,12 @@ export default function parsePublicodes<
 	Context<ContextNames | NewRulesNames>,
 	'parsedRules' | 'nodesTypes' | 'referencesMaps' | 'rulesReplacements'
 > {
-	// STEP 1 : get the rules as objects
+	// STEP 1 : get the rules as an object
+
+	if (typeof rawRules === 'string')
+		throw Error(
+			'Publicodes does not parse yaml rule sets itself anymore. Please provide a parsed js object. E.g. the `eemeli/yaml` package.'
+		)
 	let rules = { ...rawRules }
 
 	// STEP 2: Rules parsing

--- a/packages/core/source/parsePublicodes.ts
+++ b/packages/core/source/parsePublicodes.ts
@@ -1,4 +1,3 @@
-import yaml from 'yaml'
 import { Logger, ParsedRules } from '.'
 import { makeASTTransformer, traverseParsedRules } from './AST'
 import inferNodeType, { NodesTypes } from './inferNodeType'
@@ -66,19 +65,14 @@ export default function parsePublicodes<
 	ContextNames extends string,
 	NewRulesNames extends string
 >(
-	rawRules: RawPublicodes<NewRulesNames> | string,
+	rawRules: RawPublicodes<NewRulesNames>,
 	partialContext: Partial<Context<ContextNames>> = createContext({})
 ): Pick<
 	Context<ContextNames | NewRulesNames>,
 	'parsedRules' | 'nodesTypes' | 'referencesMaps' | 'rulesReplacements'
 > {
-	// STEP 1: parse Yaml
-	let rules =
-		typeof rawRules === 'string'
-			? (yaml.parse(
-					('' + rawRules).replace(/\t/g, '  ')
-			  ) as RawPublicodes<NewRulesNames>)
-			: { ...rawRules }
+	// STEP 1 : get the rules as objects
+	let rules = { ...rawRules }
 
 	// STEP 2: Rules parsing
 	const context = createContext(partialContext)

--- a/packages/core/source/ruleUtils.ts
+++ b/packages/core/source/ruleUtils.ts
@@ -9,7 +9,11 @@ import { addToMapSet } from './utils'
 import dedent from 'dedent-js'
 import yaml from 'yaml'
 
-export const parseYaml = (yamlString: string) => yaml.parse(dedent(yamlString))
+export const parseYaml = (yamlString: string) => {
+	const yo = yaml.parse(dedent(yamlString))
+	console.log(yo)
+	return yo
+}
 
 export { cyclicDependencies } from './AST/graph'
 

--- a/packages/core/source/ruleUtils.ts
+++ b/packages/core/source/ruleUtils.ts
@@ -6,6 +6,11 @@ import { ReferenceNode } from './reference'
 import { RuleNode } from './rule'
 import { addToMapSet } from './utils'
 
+import dedent from 'dedent-js'
+import yaml from 'yaml'
+
+export const parseYaml = (yamlString: string) => yaml.parse(dedent(yamlString))
+
 export { cyclicDependencies } from './AST/graph'
 
 const splitName = (str: string) => str.split(' . ')

--- a/packages/core/source/ruleUtils.ts
+++ b/packages/core/source/ruleUtils.ts
@@ -6,15 +6,6 @@ import { ReferenceNode } from './reference'
 import { RuleNode } from './rule'
 import { addToMapSet } from './utils'
 
-import dedent from 'dedent-js'
-import yaml from 'yaml'
-
-export const parseYaml = (yamlString: string) => {
-	const yo = yaml.parse(dedent(yamlString))
-	console.log(yo)
-	return yo
-}
-
 export { cyclicDependencies } from './AST/graph'
 
 const splitName = (str: string) => str.split(' . ')

--- a/packages/core/test/co2.yaml
+++ b/packages/core/test/co2.yaml
@@ -1,0 +1,108 @@
+douche:
+  icônes: 🚿
+
+douche . impact:
+  icônes: 🍃
+  unité: kgCO2eq
+  formule: impact par douche * douche . nombre
+
+douche . nombre:
+  question: Combien prenez-vous de douches ?
+  par défaut: 30 douches
+  suggestions:
+    Une par jour: 30
+
+douche . impact par douche:
+  formule: impact par litre * litres d'eau par douche
+douche . impact par litre:
+  formule: eau . impact par litre froid + chauffage . impact par litre
+douche . litres d'eau par douche:
+  icônes: 🇱
+  formule: durée de la douche * litres par minute / 1 douche
+
+douche . litres par minute:
+  unité: l/min
+  formule:
+    variations:
+      - si: pomme de douche économe
+        alors: 9
+      - sinon: 18
+  références:
+    économise l'eau: https://www.jeconomiseleau.org/index.php/particuliers/economies-par-usage/la-douche-et-le-bain
+
+douche . pomme de douche économe:
+  question: Utilisez-vous une pomme de douche économe ?
+  par défaut: non
+
+eau:
+  icônes: 💧
+
+eau . impact par litre froid:
+  unité: kgCO2eq/l
+  formule: 0.000132
+
+chauffage:
+  icônes: 🔥
+
+chauffage . type:
+  question: Comment est chauffée votre eau ?
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - gaz
+        - fioul
+        - électricité
+  par défaut: "'gaz'"
+
+chauffage . type . gaz:
+  icônes: 🔵
+chauffage . type . fioul:
+  icônes: 🛢️
+chauffage . type . électricité:
+  icônes: ⚡
+
+# définir ces éléments un par un
+
+chauffage . impact par kWh:
+  unité: kgCO2eq/kWh PCI
+  formule:
+    variations:
+      - si: type = 'gaz'
+        alors: 0.227
+      - si: type = 'fioul'
+        alors: 0.324
+      - si: type = 'électricité'
+        alors: 0.059
+
+  notes: |
+    La base carbone de l'ADEME ne permet malheureusement pas de faire des liens profonds vers les chiffres utilisés.
+    Pour l'électricité, nous retenons le chiffre de l'ADEME "Electricité - 2016 - usage : Eau Chaude Sanitaire - consommation".
+  références:
+    base carbone ADEME: http://www.bilans-ges.ademe.fr/fr/accueil
+    électricité: https://www.electricitymap.org/?page=country&solar=false&remote=true&wind=false&countryCode=FR
+    électricité sur Décrypter l'Energie: https://decrypterlenergie.org/decryptage-quel-est-le-contenu-en-co2-du-kwh-electrique
+
+chauffage . énergie consommée par litre:
+  formule: 0.0325
+  unité: kWh
+  références:
+    analyse du prix d'une douche: https://www.econologie.com/forums/plomberie-et-sanitaire/prix-reel-d-un-bain-ou-d-une-douche-pour-l-eau-et-chauffage-t12727.html
+
+chauffage . impact par litre:
+  formule: impact par kWh * énergie consommée par litre
+# Meilleure syntaxe : nouveau mécanisme correspondance
+# mais où désigne-t-on ce sur quoi la correspondance se fait ? Est-ce implicite ? Ici le chauffage.
+# formule:
+#    correspondance:
+#      gaz: 30
+#      fioul: 50
+#      électricité: 2
+
+douche . durée de la douche:
+  question: Combien de temps dure votre douche en général ?
+  par défaut: 5 min
+  suggestions:
+    expresse: 5
+    moyenne: 10
+    lente: 20

--- a/packages/core/test/cycles.test.js
+++ b/packages/core/test/cycles.test.js
@@ -1,11 +1,12 @@
 import { expect } from 'chai'
 import dedent from 'dedent-js'
 import { cyclesInDependenciesGraph } from '../source/AST/graph'
+import { parseYaml } from './utils'
 
 // Cycles due to parents dependencies are not handled currently.
 describe.skip('Cyclic dependencies detectron 3000 ™', () => {
 	it('should detect the trivial formule cycle', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			a:
 				formule: a + 1
 		`
@@ -14,7 +15,7 @@ describe.skip('Cyclic dependencies detectron 3000 ™', () => {
 	})
 
 	it('should detect nested and parallel formule cycles', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			a:
 				formule: b + 1
 			b:
@@ -29,7 +30,7 @@ describe.skip('Cyclic dependencies detectron 3000 ™', () => {
 	})
 
 	it('should not detect formule cycles due to parent dependency', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			a:
 				formule: b + 1
 			a . b:
@@ -40,7 +41,7 @@ describe.skip('Cyclic dependencies detectron 3000 ™', () => {
 	})
 
 	it('should not detect cycles when résoudre référence circulaire', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			fx:
 				200 - x
 			x:

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -1,10 +1,7 @@
 // TODO: migrate to the 100% yaml test syntax in mecanisms/inversion.yaml
 import { expect } from 'chai'
-import dedent from 'dedent-js'
 import Engine from '../source/index'
-import yaml from 'yaml'
-
-const parseYaml = (yamlString) => yaml.parse(dedent(yamlString))
+import { parseYaml } from '../source/ruleUtils'
 
 describe('inversions', () => {
 	it('should handle basic inversion', () => {

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -2,10 +2,13 @@
 import { expect } from 'chai'
 import dedent from 'dedent-js'
 import Engine from '../source/index'
+import yaml from 'yaml'
+
+const parseYaml = (yamlString) => yaml.parse(dedent(yamlString))
 
 describe('inversions', () => {
 	it('should handle basic inversion', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         a: b + 10
 
         b:
@@ -19,7 +22,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle simple inversion', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -41,7 +44,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle inversion with value at 0', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -62,7 +65,7 @@ describe('inversions', () => {
 	})
 
 	it('should handle inversions with missing variables', () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -109,26 +112,25 @@ describe('inversions', () => {
 	})
 
 	it('should reset cache after a failed inversion', () => {
-		const rules = dedent`
+		const rules = parseYaml`
 			net:
-				variations:
-					- si: assiette < 100
-						alors: 100
-					- sinon: 200
+		      variations:
+		        - si: assiette < 100
+		          alors: 100
+		        - sinon: 200
 			assiette: brut
 			brut:
-				inversion numérique:
-					avec:
-						- net
+			  inversion numérique:
+			    avec:
+			      - net
 		`
-
 		const engine = new Engine(rules)
 		engine.setSituation({ net: 150 }).evaluate('brut')
 		expect(engine.evaluate('assiette').nodeValue).to.be.undefined
 	})
 
 	it("shouldn't report a missing salary if another salary was input", () => {
-		const rules = dedent`
+		const rules = parseYaml`
         net:
           formule:
             produit:
@@ -167,7 +169,7 @@ describe('inversions', () => {
 	})
 
 	it('complex inversion with composantes', () => {
-		const rules = dedent`
+		const rules = parseYaml`
       net:
         formule:
           produit:

--- a/packages/core/test/inversion.test.js
+++ b/packages/core/test/inversion.test.js
@@ -1,7 +1,7 @@
 // TODO: migrate to the 100% yaml test syntax in mecanisms/inversion.yaml
 import { expect } from 'chai'
 import Engine from '../source/index'
-import { parseYaml } from '../source/ruleUtils'
+import { parseYaml } from './utils'
 
 describe('inversions', () => {
 	it('should handle basic inversion', () => {

--- a/packages/core/test/library.test.js
+++ b/packages/core/test/library.test.js
@@ -1,8 +1,13 @@
 import { expect } from 'chai'
 import Engine from '../source/index'
 import { parseYaml } from '../source/ruleUtils'
-import co2Rules from './co2.yaml'
 import { parse } from 'yaml'
+
+import { fileURLToPath } from 'url'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+import fs from 'fs'
+import path from 'path'
 
 describe('library', function () {
 	it('should let the user define its own rule', function () {
@@ -63,6 +68,9 @@ impôt sur le revenu à payer:
 	})
 
 	it('should let the user define a rule base on a completely different subject', function () {
+		const co2Rules = parse(
+			fs.readFileSync(path.resolve(__dirname, './co2.yaml'))
+		)
 		let engine = new Engine(parse(co2Rules))
 		engine.setSituation({
 			'douche . nombre': 30,

--- a/packages/core/test/library.test.js
+++ b/packages/core/test/library.test.js
@@ -1,9 +1,12 @@
 import { expect } from 'chai'
 import Engine from '../source/index'
+import { parseYaml } from '../source/ruleUtils'
+import co2Rules from './co2.yaml'
+import { parse } from 'yaml'
 
 describe('library', function () {
 	it('should let the user define its own rule', function () {
-		let rules = `
+		let rules = parseYaml`
 yo:
   formule: 200
 ya:
@@ -18,7 +21,7 @@ yi:
 	})
 
 	it('should let the user define a simplified revenue tax system', function () {
-		let rules = `
+		let rules = parseYaml`
 revenu imposable:
   question: Quel est votre revenu imposable ?
   unité: €
@@ -60,7 +63,7 @@ impôt sur le revenu à payer:
 	})
 
 	it('should let the user define a rule base on a completely different subject', function () {
-		let engine = new Engine(co2Rules)
+		let engine = new Engine(parse(co2Rules))
 		engine.setSituation({
 			'douche . nombre': 30,
 			'chauffage . type': "'gaz'",
@@ -70,114 +73,3 @@ impôt sur le revenu à payer:
 		expect(value.nodeValue).to.be.within(40, 41)
 	})
 })
-
-const co2Rules = `
-douche:
-  icônes: 🚿
-
-douche . impact:
-  icônes: 🍃
-  unité: kgCO2eq
-  formule: impact par douche * douche . nombre
-
-douche . nombre:
-  question: Combien prenez-vous de douches ?
-  par défaut: 30 douches
-  suggestions:
-    Une par jour: 30
-
-douche . impact par douche:
-  formule: impact par litre * litres d'eau par douche
-douche . impact par litre:
-  formule: eau . impact par litre froid + chauffage . impact par litre
-douche . litres d'eau par douche:
-  icônes: 🇱
-  formule: durée de la douche * litres par minute / 1 douche
-
-douche . litres par minute:
-  unité: l/min
-  formule:
-    variations:
-      - si: pomme de douche économe
-        alors: 9
-      - sinon: 18
-  références:
-    économise l'eau: https://www.jeconomiseleau.org/index.php/particuliers/economies-par-usage/la-douche-et-le-bain
-
-douche . pomme de douche économe:
-  question: Utilisez-vous une pomme de douche économe ?
-  par défaut: non
-
-eau:
-  icônes: 💧
-
-eau . impact par litre froid:
-  unité: kgCO2eq/l
-  formule: 0.000132
-
-chauffage:
-  icônes: 🔥
-
-chauffage . type:
-  question: Comment est chauffée votre eau ?
-  formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - gaz
-        - fioul
-        - électricité
-  par défaut: "'gaz'"
-
-chauffage . type . gaz:
-  icônes: 🔵
-chauffage . type . fioul:
-  icônes: 🛢️
-chauffage . type . électricité:
-  icônes: ⚡
-
-# définir ces éléments un par un
-
-chauffage . impact par kWh:
-  unité: kgCO2eq/kWh PCI
-  formule:
-    variations:
-      - si: type = 'gaz'
-        alors: 0.227
-      - si: type = 'fioul'
-        alors: 0.324
-      - si: type = 'électricité'
-        alors: 0.059
-
-  notes: |
-    La base carbone de l'ADEME ne permet malheureusement pas de faire des liens profonds vers les chiffres utilisés.
-    Pour l'électricité, nous retenons le chiffre de l'ADEME "Electricité - 2016 - usage : Eau Chaude Sanitaire - consommation".
-  références:
-    base carbone ADEME: http://www.bilans-ges.ademe.fr/fr/accueil
-    électricité: https://www.electricitymap.org/?page=country&solar=false&remote=true&wind=false&countryCode=FR
-    électricité sur Décrypter l'Energie: https://decrypterlenergie.org/decryptage-quel-est-le-contenu-en-co2-du-kwh-electrique
-
-chauffage . énergie consommée par litre:
-  formule: 0.0325
-  unité: kWh
-  références:
-    analyse du prix d'une douche: https://www.econologie.com/forums/plomberie-et-sanitaire/prix-reel-d-un-bain-ou-d-une-douche-pour-l-eau-et-chauffage-t12727.html
-
-chauffage . impact par litre:
-  formule: impact par kWh * énergie consommée par litre
-# Meilleure syntaxe : nouveau mécanisme correspondance
-# mais où désigne-t-on ce sur quoi la correspondance se fait ? Est-ce implicite ? Ici le chauffage.
-# formule:
-#    correspondance:
-#      gaz: 30
-#      fioul: 50
-#      électricité: 2
-
-douche . durée de la douche:
-  question: Combien de temps dure votre douche en général ?
-  par défaut: 5 min
-  suggestions:
-    expresse: 5
-    moyenne: 10
-    lente: 20
-`

--- a/packages/core/test/library.test.js
+++ b/packages/core/test/library.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import Engine from '../source/index'
-import { parseYaml } from '../source/ruleUtils'
+import { parseYaml } from './utils.ts'
 import { parse } from 'yaml'
 
 import { fileURLToPath } from 'url'
@@ -9,16 +9,19 @@ const __dirname = path.dirname(__filename)
 import fs from 'fs'
 import path from 'path'
 
+const co2Yaml = fs.readFileSync(path.resolve(__dirname, './co2.yaml'), 'utf8')
+
 describe('library', function () {
 	it('should let the user define its own rule', function () {
-		let rules = parseYaml`
+		let rules = parse(`
 yo:
   formule: 200
 ya:
   formule:  yo + 1
 yi:
   formule:  yo + 2
-`
+`)
+
 		let engine = new Engine(rules)
 
 		expect(engine.evaluate('ya').nodeValue).to.equal(201)
@@ -26,15 +29,15 @@ yi:
 	})
 
 	it('should let the user define a simplified revenue tax system', function () {
-		let rules = parseYaml`
+		let rules = parse(`
 revenu imposable:
   question: Quel est votre revenu imposable ?
   unité: €
 
 revenu abattu:
   formule:
-		valeur: revenu imposable
-		abattement: 10%
+    valeur: revenu imposable
+    abattement: 10%
 
 impôt sur le revenu:
   formule:
@@ -53,11 +56,11 @@ impôt sur le revenu:
 
 impôt sur le revenu à payer:
   formule:
-		valeur: impôt sur le revenu
-		abattement:
-			valeur: 1177 - (75% * impôt sur le revenu)
-			plancher: 0
-`
+    valeur: impôt sur le revenu
+    abattement:
+      valeur: 1177 - (75% * impôt sur le revenu)
+      plancher: 0
+`)
 
 		let engine = new Engine(rules)
 		engine.setSituation({
@@ -68,10 +71,7 @@ impôt sur le revenu à payer:
 	})
 
 	it('should let the user define a rule base on a completely different subject', function () {
-		const co2Rules = parse(
-			fs.readFileSync(path.resolve(__dirname, './co2.yaml'))
-		)
-		let engine = new Engine(parse(co2Rules))
+		let engine = new Engine(parse(co2Yaml))
 		engine.setSituation({
 			'douche . nombre': 30,
 			'chauffage . type': "'gaz'",

--- a/packages/core/test/mecanisms.test.ts
+++ b/packages/core/test/mecanisms.test.ts
@@ -11,13 +11,14 @@ import Engine from '../source/index'
 import { Rule } from '../source/rule'
 import { parseUnit } from '../source/units'
 import testSuites from './mécanismes/index'
+import { parse } from 'yaml'
 
 testSuites.forEach(([suiteName, suite]) => {
 	// if (suiteName !== 'résoudre-référence-circulaire') {
 	// 	return
 	// }
 	describe(`Mécanisme ${suiteName}`, () => {
-		const engine = new Engine(suite)
+		const engine = new Engine(parse(suite))
 		Object.entries(engine.getParsedRules())
 			.filter(([, rule]) => !!rule.rawNode.exemples)
 			.forEach(([name, test]) => {

--- a/packages/core/test/missingVariables.test.js
+++ b/packages/core/test/missingVariables.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import yaml from 'yaml'
 import Engine from '../source/index'
-import { parseYaml } from '../source/ruleUtils'
+import { parseYaml } from './utils.ts'
 
 describe('Missing variables', function () {
 	it('should identify missing variables in applicability', function () {
@@ -105,10 +105,10 @@ describe('Missing variables', function () {
 
 	it('should ignore missing variables from the parent', () => {
 		const rawRules = parseYaml`
-		a:
-			somme:
-			- nom: b
-			- nom: c`
+		  a:
+		    somme:
+		      - nom: b
+		      - nom: c`
 		const missingVariables = new Engine(rawRules).evaluate(
 			'a . b'
 		).missingVariables

--- a/packages/core/test/missingVariables.test.js
+++ b/packages/core/test/missingVariables.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import yaml from 'yaml'
 import Engine from '../source/index'
+import { parseYaml } from '../source/ruleUtils'
 
 describe('Missing variables', function () {
 	it('should identify missing variables in applicability', function () {
@@ -103,7 +104,7 @@ describe('Missing variables', function () {
 	})
 
 	it('should ignore missing variables from the parent', () => {
-		const rawRules = `
+		const rawRules = parseYaml`
 		a:
 			somme:
 			- nom: b
@@ -116,12 +117,13 @@ describe('Missing variables', function () {
 	})
 
 	it('should ignore missing variables from the nullable parent', () => {
-		const rawRules = `
-		a:
-			applicable si: oui
-			somme:
-				- nom: b
-				- nom: c`
+		const rawRules = parseYaml`
+  a:
+    applicable si: oui
+    somme:
+      - nom: b
+      - nom: c
+`
 		const missingVariables = new Engine(rawRules).evaluate(
 			'a . b'
 		).missingVariables

--- a/packages/core/test/recalcul.test.ts
+++ b/packages/core/test/recalcul.test.ts
@@ -3,12 +3,13 @@ import 'mocha'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import Engine from '../source'
-import { parseYaml } from '../source/ruleUtils'
+import { parseYaml } from './utils'
+import { parse } from 'yaml'
 
 chai.use(sinonChai)
 
 describe('When two different recalculs are nested', () => {
-	const rulesYaml = `
+	const rulesYaml = parse(`
 a: 1
 b: a * 2
 c:
@@ -21,7 +22,7 @@ d:
     règle: c
     avec:
       a: 100
-`
+`)
 	const sandbox = sinon.createSandbox()
 
 	beforeEach(() => {
@@ -55,15 +56,15 @@ d:
 
 describe('When rule recalculing itself', () => {
 	const rulesYaml = parseYaml`
-a: 100 €
-r:
-  produit:
-    assiette: a
-    taux: 50%
-  plafond:
-    recalcul:
-      avec:
-        a: 1000 €
+		a: 100 €
+		r:
+		  produit:
+		    assiette: a
+		    taux: 50%
+		  plafond:
+		    recalcul:
+		      avec:
+		        a: 1000 €
 `
 	const sandbox = sinon.createSandbox()
 

--- a/packages/core/test/recalcul.test.ts
+++ b/packages/core/test/recalcul.test.ts
@@ -3,6 +3,7 @@ import 'mocha'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import Engine from '../source'
+import { parseYaml } from '../source/ruleUtils'
 
 chai.use(sinonChai)
 
@@ -53,7 +54,7 @@ d:
 })
 
 describe('When rule recalculing itself', () => {
-	const rulesYaml = `
+	const rulesYaml = parseYaml`
 a: 100 €
 r:
   produit:

--- a/packages/core/test/situation.test.ts
+++ b/packages/core/test/situation.test.ts
@@ -1,37 +1,39 @@
 import { expect } from 'chai'
 import Engine from '../source/index'
+import { engineFromYaml, parseYaml } from './utils'
 
 describe('setSituation', () => {
 	it('should allow to evaluate without situation', () => {
-		expect(new Engine('a: ').evaluate('a').nodeValue).to.eq(undefined)
+		expect(engineFromYaml('a: ').evaluate('a').nodeValue).to.eq(undefined)
 	})
 	it('should allow to evaluate with situation set', () => {
 		expect(
-			new Engine('a: ').setSituation({ a: 5 }).evaluate('a').nodeValue
+			engineFromYaml('a: ').setSituation({ a: 5 }).evaluate('a').nodeValue
 		).to.eq(5)
 	})
 	it('should overwrite initial value with situation', () => {
 		expect(
-			new Engine('a: 10').setSituation({ a: 5 }).evaluate('a').nodeValue
+			engineFromYaml('a: 10').setSituation({ a: 5 }).evaluate('a').nodeValue
 		).to.eq(5)
 	})
 	it('should not allow to set situation for private rule', () => {
-		expect(() => new Engine('[privé] a: 10').setSituation({ a: 5 })).to.throw
+		expect(() => engineFromYaml('[privé] a: 10').setSituation({ a: 5 })).to
+			.throw
 	})
 	it('should report missing variables depth first', () => {
 		expect(
-			new Engine('a:\nb: a').evaluate('b').missingVariables
+			engineFromYaml('a:\nb: a').evaluate('b').missingVariables
 		).to.have.all.keys('a')
 	})
 
 	it('should not show private missing variables', () => {
 		expect(
-			new Engine('"[privé] a":\nb: a').evaluate('b').missingVariables
+			engineFromYaml('"[privé] a":\nb: a').evaluate('b').missingVariables
 		).to.have.all.keys('b')
 	})
 
 	it('should let the user reference rules in the situation', function () {
-		let rules = `
+		let rules = parseYaml`
 	referenced in situation:
 	  formule: 200
 	overwrited in situation:
@@ -47,7 +49,7 @@ describe('setSituation', () => {
 	})
 
 	it('should allow to create rules in the situation', function () {
-		let engine = new Engine('a:')
+		let engine = engineFromYaml('a:')
 		engine.setSituation({
 			a: {
 				valeur: 'b',
@@ -60,7 +62,7 @@ describe('setSituation', () => {
 	})
 
 	it('should allow to replace rules in the situation', function () {
-		let engine = new Engine('a: 5\nb:')
+		let engine = engineFromYaml('a: 5\nb:')
 		engine.setSituation({
 			b: {
 				valeur: 10,
@@ -71,7 +73,7 @@ describe('setSituation', () => {
 	})
 
 	it('should allow to keep previous situation', () => {
-		let engine = new Engine('a:\nb:\nc:')
+		let engine = engineFromYaml('a:\nb:\nc:')
 			.setSituation({ a: 5, c: 3 })
 			.setSituation({ b: 10, c: 'a' }, { keepPreviousSituation: true })
 		expect(engine.evaluate('a').nodeValue).to.equal(5)

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -1,0 +1,9 @@
+import { parse } from 'yaml'
+import dedent from 'dedent-js'
+import Engine from '../source/index'
+
+export const parseYaml = (yamlString: string) => {
+	return parse(dedent(yamlString))
+}
+
+export const engineFromYaml = (yaml: string) => new Engine(parse(yaml))

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
 	sourcemap: true,
 	clean: true,
 	dts: true,
+	loader: {
+		'.yaml': 'text',
+	},
 })

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,7 +7,4 @@ export default defineConfig({
 	sourcemap: true,
 	clean: true,
 	dts: true,
-	loader: {
-		'.yaml': 'text',
-	},
 })

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.46",
+	"version": "1.0.0-beta.47",
 	"description": "UI to explore publicodes computations",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/website/docs/api.mdx
+++ b/website/docs/api.mdx
@@ -17,9 +17,10 @@ Crée un moteur d'évaluation avec les règles publicodes données en argument.
 
 **Arguments**
 
-- `rules` : les règles publicodes utilisées. Ces dernières peuvent être sous la
-  forme d'une chaîne de caractère `yaml` publicodes (ou d'un objet javascript
-  correspondant). Elle peuvent aussi être sous la forme de règles publicodes déjà parsées.
+- `rules` : les règles publicodes utilisées. Ces dernières doivent être sous la
+  forme d'un objet javascript respectant la syntaxe publicodes. Elle peuvent aussi être sous la forme de règles publicodes déjà parsées.
+
+> publicodes n'accepte plus en entrée une chaîne de caractères YAML, car le parser YAML alourdissait beaucoup la biblitothèque
 
 **Retourne**
 Un moteur d'évaluation qui expose les fonctions suivantes :

--- a/website/docs/tutoriel.mdx
+++ b/website/docs/tutoriel.mdx
@@ -106,7 +106,7 @@ const engine = new Engine(parsedRules)
 Pourquoi ne pas accepter du YAML en entrée de publicodes, alors que cette syntaxe est effectivement plus agréable que du JSON ? 
 
 Parce que l'étape de parsing du YAML nécessite d'embarquer une lourde bibliothèque. 
-Libre ainsi à chaque projet de faire cette étape au moment et à l'endroit le plus adapté, côté serveur 
+Libre ainsi à chaque projet de faire cette étape au moment et à l'endroit le plus adapté, côté serveur ou lors du build de l’application
 
 > Il est donc également tout à fait possible d'initialiser `Engine` avec un objet JSON, il suffit de le parser avec la fonction native `JSON.parse(monJSON)`.
 > Le JSON étant le langage dominant des APIs (on n'échange jamais de YAML par API), c'est un moyen en pratique courant de le faire.

--- a/website/docs/tutoriel.mdx
+++ b/website/docs/tutoriel.mdx
@@ -78,6 +78,7 @@ jeu de règles publicodes.
 
 ```js
 import Engine from 'publicodes'
+import {parse} from 'yaml'
 
 // On définit une liste de règles publicodes
 const rules = `
@@ -93,11 +94,23 @@ dépenses primeur:
       - prix . champignons * 500g
       - prix . avocat * 3 avocat
 `
+// publicodes ne prend plus en entrée du YAML, vous devez parser vous-même votre code source 
+const parsedRules = parse(rules)
 
-// On initialise un moteur en lui donnant le publicodes.
+// On initialise un moteur en lui donnant le publicodes sous forme d'objet javascript.
 // Ce publicodes va être parsé
-const engine = new Engine(rules)
+const engine = new Engine(parsedRules)
 ```
+
+
+Pourquoi ne pas accepter du YAML en entrée de publicodes, alors que cette syntaxe est effectivement plus agréable que du JSON ? 
+
+Parce que l'étape de parsing du YAML nécessite d'embarquer une lourde bibliothèque. 
+Libre ainsi à chaque projet de faire cette étape au moment et à l'endroit le plus adapté, côté serveur 
+
+> Il est donc également tout à fait possible d'initialiser `Engine` avec un objet JSON, il suffit de le parser avec la fonction native `JSON.parse(monJSON)`.
+> Le JSON étant le langage dominant des APIs (on n'échange jamais de YAML par API), c'est un moyen en pratique courant de le faire.
+
 
 La variable `engine` permet en ensuite de calculer la valeur d'une règle avec la
 méthode `evaluate` :
@@ -175,11 +188,10 @@ valeur d'une dépendance est manquante et ne permet pas de faire le calcul, elle
 apparaîtra dans la propriété `missingVariables` :
 
 ```js
-const missingYEngine = new Engine(`
-x: y + 5
-
-y:
-`)
+const missingYEngine = new Engine({
+		x: 'y + 5',
+		y: null
+})
 
 console.log(missingYEngine.evaluate('x').missingVariables)
 ```

--- a/website/src/components/Documentation.tsx
+++ b/website/src/components/Documentation.tsx
@@ -6,6 +6,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useHistory, useLocation } from 'react-router-dom'
 import ErrorBoundary, { nl2br } from './ErrorBoundary'
 
+// this is a heavy library, this component shoudl be lazy loaded
+import { parse } from 'yaml'
+
 type ResultsProps = {
 	rules: string
 	onClickShare?: React.MouseEventHandler
@@ -49,7 +52,10 @@ export default function Documentation({
 	baseUrl,
 }: ResultsProps) {
 	const logger = useMemo(() => new Logger(), [rules])
-	const engine = useMemo(() => new Engine(rules, { logger }), [rules, logger])
+	const engine = useMemo(
+		() => new Engine(parse(rules), { logger }),
+		[rules, logger]
+	)
 	const targets = useMemo(() => Object.keys(engine.getParsedRules()), [engine])
 	const pathToRules = useMemo(
 		() => getDocumentationSiteMap({ engine, documentationPath: '' }),

--- a/website/src/components/Playground.tsx
+++ b/website/src/components/Playground.tsx
@@ -1,0 +1,42 @@
+import type {} from '@docusaurus/theme-classic' // required for @theme/CodeBlock types
+import { usePrismTheme } from '@docusaurus/theme-common'
+import styles from '@docusaurus/theme-live-codeblock/src/theme/Playground/styles.module.css'
+import React from 'react'
+import { Editor } from 'react-live'
+import Documentation from './Documentation'
+import ErrorBoundary from './ErrorBoundary'
+import publicodeStyles from './publicodeExample.module.css'
+
+export default function Playground({
+	language,
+	defaultTarget,
+	onTargetChange,
+	onChange,
+	children,
+	...props
+}): JSX.Element {
+	const prismTheme = usePrismTheme()
+
+	return (
+		<div className={styles.playgroundContainer}>
+			<div className={styles.playgroundHeader}>Editeur live</div>
+			<Editor
+				{...props}
+				code={children}
+				theme={prismTheme}
+				language={language}
+				disabled={false}
+				className={styles.playgroundEditor + ' ' + publicodeStyles.editor}
+				onChange={onChange}
+			/>
+			<ErrorBoundary key={children}>
+				<Documentation
+					rules={children}
+					defaultTarget={defaultTarget}
+					onTargetChange={onTargetChange}
+				/>
+				<div style={{ paddingBottom: '1rem' }} />
+			</ErrorBoundary>
+		</div>
+	)
+}

--- a/website/src/components/PublicodeExample.tsx
+++ b/website/src/components/PublicodeExample.tsx
@@ -1,46 +1,8 @@
-import React, { useEffect, useState } from 'react'
-import { Editor } from 'react-live'
-import { usePrismTheme } from '@docusaurus/theme-common'
-import styles from '@docusaurus/theme-live-codeblock/src/theme/Playground/styles.module.css'
 import type {} from '@docusaurus/theme-classic' // required for @theme/CodeBlock types
 import CodeBlock from '@theme/CodeBlock'
-import Documentation from './Documentation'
-import ErrorBoundary from './ErrorBoundary'
+import React, { lazy, Suspense, useEffect, useState } from 'react'
 import publicodeStyles from './publicodeExample.module.css'
-
-function Playground({
-	language,
-	defaultTarget,
-	onTargetChange,
-	onChange,
-	children,
-	...props
-}): JSX.Element {
-	const prismTheme = usePrismTheme()
-
-	return (
-		<div className={styles.playgroundContainer}>
-			<div className={styles.playgroundHeader}>Editeur live</div>
-			<Editor
-				{...props}
-				code={children}
-				theme={prismTheme}
-				language={language}
-				disabled={false}
-				className={styles.playgroundEditor + ' ' + publicodeStyles.editor}
-				onChange={onChange}
-			/>
-			<ErrorBoundary key={children}>
-				<Documentation
-					rules={children}
-					defaultTarget={defaultTarget}
-					onTargetChange={onTargetChange}
-				/>
-				<div style={{ paddingBottom: '1rem' }} />
-			</ErrorBoundary>
-		</div>
-	)
-}
+const Playground = lazy(() => import('./Playground'))
 
 interface PublicodeExampleProps {
 	rules: string
@@ -69,14 +31,16 @@ export default function PublicodeExample({
 			{!edit ? (
 				<CodeBlock language={language}>{code}</CodeBlock>
 			) : (
-				<Playground
-					language={language}
-					defaultTarget={target}
-					onTargetChange={setTarget}
-					onChange={(text) => setCode(text)}
-				>
-					{code}
-				</Playground>
+				<Suspense fallback={<div>Chargement en cours</div>}>
+					<Playground
+						language={language}
+						defaultTarget={target}
+						onTargetChange={setTarget}
+						onChange={(text) => setCode(text)}
+					>
+						{code}
+					</Playground>
+				</Suspense>
 			)}
 			<button
 				className={publicodeStyles.button}

--- a/website/src/pages/api-rest.mdx
+++ b/website/src/pages/api-rest.mdx
@@ -47,7 +47,7 @@ const app = new Koa()
 const router = new Router()
 
 // Create middleware with your Engine
-const apiRoutes = publicodesAPI(new Engine('coucou: 0'))
+const apiRoutes = publicodesAPI(new Engine({coucou: 0}))
 
 // Basic routes usage (/evaluate, /rules, etc.)
 router.use(apiRoutes)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,14 +4014,14 @@ __metadata:
     koa-body: ^5.0.0
     nodemon: ^2.0.16
     openapi-validator-middleware: ^3.2.6
-    publicodes: ^1.0.0-beta.46
+    publicodes: ^1.0.0-beta.47
     ts-node: ^10.8.0
     tsup: ^6.0.1
     typescript: ^4.7.2
     vitest: ^0.12.9
     wait-on: ^6.0.1
   peerDependencies:
-    publicodes: ^1.0.0-beta.46
+    publicodes: ^1.0.0-beta.47
   languageName: unknown
   linkType: soft
 
@@ -13582,7 +13582,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"publicodes@^1.0.0-beta.46, publicodes@workspace:^, publicodes@workspace:packages/core":
+"publicodes@^1.0.0-beta.47, publicodes@workspace:^, publicodes@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "publicodes@workspace:packages/core"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -13562,6 +13562,7 @@ __metadata:
   resolution: "publicodes-monorepo@workspace:."
   dependencies:
     prettier: ^2.5.1
+    yaml: ^2.1.1
   languageName: unknown
   linkType: soft
 
@@ -13601,7 +13602,6 @@ __metadata:
     ts-node: ^10.7.0
     tsup: ^6.0.1
     typescript: ^4.5.5
-    yaml: ^1.9.2
   peerDependencies:
     "@types/mocha": ^9.0.0
   languageName: unknown
@@ -17333,10 +17333,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2, yaml@npm:^1.9.2":
+"yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "yaml@npm:2.1.1"
+  checksum: f48bb209918aa57cfaf78ef6448d1a1f8187f45c746f933268b7023dc59e5456004611879126c9bb5ea55b0a2b1c2b392dfde436931ece0c703a3d754562bb96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> Supersedes #243 

Partial fix to #124

The idea here is to simply remove the yaml parser from the publicode bundle. 

It would be the responsability of the client to transform his object
representation (YAML, JSON) to a Javascript object when initialising the
Engine. 

- [x] rewrite the other test suites

What do you think ? 

This PR would be a breaking change of course. But as far as I know, very easily corrected by client libraries, that would benefit a lot : 
- for browser side publicode usage, the weight gain is 3/5 (!)
- for server side, the client can use its prefered yaml parser

![image](https://user-images.githubusercontent.com/1177762/178462453-41852f1f-4af2-4220-b340-b66f2196d7ea.png)



- [x] actualiser la doc pour préciser tout ça, dont le changement d'API
- [x] ajouter un paragraphe sur le lien entre yaml et publicodes. 
