### PR TITLE
Corrige le score des règle avec le mécanisme par défaut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## 1.0.0-beta.54
+
+**core**
+
+-   Corrige le score dans missingVariables des règles avec un mécanisme `par défaut` #269
+
 ## 1.0.0-beta.53
 
 **publicodes-react**
 
--   Ajoute un avertissement dans la section réutilisation si il s'agit d'une règle tagguée comme experimentale
--   Enlève l'utilisation de Array.at qui causait un bug critique sur safari
+-   Ajoute un avertissement dans la section réutilisation si il s’agit d’une règle tagguée comme experimentale
+-   Enlève l’utilisation de Array.at qui causait un bug critique sur safari
 
 **api**
 
@@ -14,38 +20,38 @@
 
 **core**
 
--   Enlève les messages d'avertissement liés aux cycles : ils se déclenchaient tout le temps sur la base de règle mon-entreprise, en attendant d'implémenter une vérification plus solide
+-   Enlève les messages d’avertissement liés aux cycles : ils se déclenchaient tout le temps sur la base de règle mon-entreprise, en attendant d’implémenter une vérification plus solide
 
 ## 1.0.0-beta.52
 
 **publicodes-react**
 
--   Corrige un bug d'affichage dans la documentation
+-   Corrige un bug d’affichage dans la documentation
 
 ## 1.0.0-beta.51
 
 **publicodes-react**
 
--   Corrige un bug d'affichage dans la documentation
+-   Corrige un bug d’affichage dans la documentation
 
 ## 1.0.0-beta.50
 
 **publicodes-react**
 
--   Affiche les titre des règles parentes à côté du titre de la règle dans les liens. Cela permet d'ajouter du contexte et de désambiguisé les noms de règles dans les listes.
+-   Affiche les titre des règles parentes à côté du titre de la règle dans les liens. Cela permet d’ajouter du contexte et de désambiguisé les noms de règles dans les listes.
 -   Améliore le style du menu de navigation
 
 ## 1.0.0-beta.49
 
 **core**
 
--   Ajout d'informations pour les développeurs dans la documentation.
--   **⚠ Changement cassant :** Uniformisation des erreurs throw par publicodes avec un nouveau type d'erreur : `PublicodesError`
--   Ajout d'une fonction `isPublicodesError` qui permet de detecter une erreur publicodes et de la typer
--   Ajout d'un attribut `dottedName` au erreurs `SyntaxError`, `EvaluationError`, `UnknownRule` et `PrivateRule`
+-   Ajout d’informations pour les développeurs dans la documentation.
+-   **⚠ Changement cassant :** Uniformisation des erreurs throw par publicodes avec un nouveau type d’erreur : `PublicodesError`
+-   Ajout d’une fonction `isPublicodesError` qui permet de detecter une erreur publicodes et de la typer
+-   Ajout d’un attribut `dottedName` au erreurs `SyntaxError`, `EvaluationError`, `UnknownRule` et `PrivateRule`
 -   Remplace la fonction `neverHappens` par une erreur `UnreachableCaseError`
--   Ajout d'une arborescence des règles dans la documentation [#250](https://github.com/betagouv/publicodes/pull/250)
--   Répare l'inférence d'unité dans une somme avec un élément non applicable [#252](https://github.com/betagouv/publicodes/pull/252)
+-   Ajout d’une arborescence des règles dans la documentation [#250](https://github.com/betagouv/publicodes/pull/250)
+-   Répare l’inférence d’unité dans une somme avec un élément non applicable [#252](https://github.com/betagouv/publicodes/pull/252)
 
 ## 1.0.0-beta.48
 
@@ -55,7 +61,7 @@
 
 **core**
 
--   **⚠ Changement cassant** Enlève la possibilité d'initialiser l'`Engine` avec un string YAML. Le client doit se charger du parsing lui-même.
+-   **⚠ Changement cassant** Enlève la possibilité d’initialiser l’`Engine` avec un string YAML. Le client doit se charger du parsing lui-même.
 
 ## 1.0.0-beta.46
 
@@ -74,30 +80,30 @@
 
 -   Ajoute la possibilité de définir des **règles privée**
 -   La situation est maintenant encodée sous forme de règle publicodes
--   Améliore les performances des mécanismes "le maximum de" et "le minimum de"
--   **⚠ Changement cassant** Simplifie l'API de l'Engine en supprimant les fonctions `setOptions`, `getOptions`
--   Ajoute une fonction `evaluateNode` pour évaluer les noeud déjà parsés. Dans l'idéal cette fonction ne devrait pas être exposée aux utilisateurs
--   Supprime le tri par ordre topologique avant l'inference de type : il suffit de parcourir le graphe en mode "profondeur d'abord" pour avoir le même résultat (améliore les performances)
--   Ajoute un mécanisme `avec` pour pouvoir définir des règles imbriquées à n'importe quel endroit (comme pour `nom`)
+-   Améliore les performances des mécanismes “le maximum de” et “le minimum de”
+-   **⚠ Changement cassant** Simplifie l’API de l’Engine en supprimant les fonctions `setOptions`, `getOptions`
+-   Ajoute une fonction `evaluateNode` pour évaluer les noeud déjà parsés. Dans l’idéal cette fonction ne devrait pas être exposée aux utilisateurs
+-   Supprime le tri par ordre topologique avant l’inference de type : il suffit de parcourir le graphe en mode “profondeur d’abord” pour avoir le même résultat (améliore les performances)
+-   Ajoute un mécanisme `avec` pour pouvoir définir des règles imbriquées à n’importe quel endroit (comme pour `nom`)
 -   Ajoute une option `keepPreviousSituation: boolean` à la méthode `setSituation` pour effectuer une mise à jour non destructive de la situation
--   Le mécanisme `résoudre la référence circulaire` prend maintenant en compte l'option `inversionMaxIterations`
--   **⚠ Changement cassant** Supprime l'écriture `[ref]` pour ajouter des variables nommées. L'implémentation de cette dernière obligeait à parcourir l'arbre en entier ce qui prenait 300ms sur mon-entreprise.
+-   Le mécanisme `résoudre la référence circulaire` prend maintenant en compte l’option `inversionMaxIterations`
+-   **⚠ Changement cassant** Supprime l’écriture `[ref]` pour ajouter des variables nommées. L’implémentation de cette dernière obligeait à parcourir l’arbre en entier ce qui prenait 300ms sur mon-entreprise.
 -   Optimise `inlineReplacement` : seule les règles contenant une référence remplacée sont parcourues.
 -   Supprime la notion de circularDependancies
--   Supprime le nombre magique "12" pour la détection de cycle au runtime
+-   Supprime le nombre magique “12” pour la détection de cycle au runtime
 -   Supprime le rennomage automatique des règles imbriquées
 
 ## 1.0.0-beta.43
 
 **api**
 
--   fix temporaire d'une fuite de mémoire dans l'api causée par `shallowCopy()`, issue https://github.com/betagouv/publicodes/issues/239
+-   fix temporaire d’une fuite de mémoire dans l’api causée par `shallowCopy()`, issue https://github.com/betagouv/publicodes/issues/239
 
 ## 1.0.0-beta.42
 
 **api**
 
--   Refacto de /evaluate : Renvoie `situationError` directement s'il y a une erreur de situation (sans faire d'évaluation) et sinon renvoie `evaluate`.
+-   Refacto de /evaluate : Renvoie `situationError` directement s’il y a une erreur de situation (sans faire d’évaluation) et sinon renvoie `evaluate`.
 -   Refacto des schema expressions et situation
 -   Ajout de documentation
 
@@ -106,36 +112,36 @@
 **api**
 
 -   Remplace le paramètre du middleware par un Engine (remplace `publicodesAPI(() => new Engine(rule))` par `publicodesAPI(new Engine(rule))`)
--   Les expressions acceptent des objets ou des tableaux d'objets
+-   Les expressions acceptent des objets ou des tableaux d’objets
 
 ## 1.0.0-beta.40
 
 **core**
 
--   Répare un bug dans les mécanismes 'le maximum de' et 'le minimum de' lorsque toutes les valeurs sont non applicables
+-   Répare un bug dans les mécanismes ‘le maximum de’ et ‘le minimum de’ lorsque toutes les valeurs sont non applicables
 
 ## 1.0.0-beta.39
 
 **core**
 
--   Répare un bug dans les mécanismes 'le maximum de' et 'le minimum de' en cas de valeur non applicable
+-   Répare un bug dans les mécanismes ‘le maximum de’ et ‘le minimum de’ en cas de valeur non applicable
 
 ## 1.0.0-beta.38
 
 **core**
 
--   Rétabli les `missingVariables` calculées à l'intérieur des mécanismes (précédement supprimée dans beta.34)
+-   Rétabli les `missingVariables` calculées à l’intérieur des mécanismes (précédement supprimée dans beta.34)
 -   Ajoute des nouveaux mécanismes : `et`, `ou`, `est non applicable`, `est applicable`, `est non défini`, `est défini`, `simplifier l'unité`, `condition`
--   Change le comportement de l'addition d'un nombre avec unité et d'un pourcentage : on ajoute le pourcentage du nombre au nombre lui même (`10€ + 20% = 10.2 €`)
--   Réecrit les mécanismes `somme`, `produit`, `applicable si`, `non applicable si`, `toutes ces conditions`, `une de ces conditions`, `le maximum de`, `le minimum de`, `abattement` comme composition d'autres mécanismes #23
+-   Change le comportement de l’addition d’un nombre avec unité et d’un pourcentage : on ajoute le pourcentage du nombre au nombre lui même (`10€ + 20% = 10.2 €`)
+-   Réecrit les mécanismes `somme`, `produit`, `applicable si`, `non applicable si`, `toutes ces conditions`, `une de ces conditions`, `le maximum de`, `le minimum de`, `abattement` comme composition d’autres mécanismes #23
 -   Les opérandes des opérations `et`, `ou`, `*`, `/` sont évaluée de manière paresseuse.
--   Précise le comportement des opérations de base (\*, +, -, /, >=, <=, <, >, =, et, ou) en cas d'opérande non défini ou non applicable (via des tests)
+-   Précise le comportement des opérations de base (\*, +, -, /, >=, <=, <, >, =, et, ou) en cas d’opérande non défini ou non applicable (via des tests)
 
 **publicodes-react**
 
--   Améliore la visualisation des mécanismes qui opère sur des listes (somme, toutes ces conditions, etc...)
--   Améliorations diverses de l'affichage de l'explication des calculs
--   Reformule l'explication des règles désactivées par l'espace de nom
+-   Améliore la visualisation des mécanismes qui opère sur des listes (somme, toutes ces conditions, etc…)
+-   Améliorations diverses de l’affichage de l’explication des calculs
+-   Reformule l’explication des règles désactivées par l’espace de nom
 
 ## 1.0.0-beta.37
 
@@ -159,21 +165,21 @@
 
 **core**
 
--   ⚠ Changement cassant : Les variables manquantes sont désormais retournées sous la forme d'une liste et non plus d'un objet JavaScript
--   Introduction des variables traversées : les listes des règles qui ont été explorées lors de l'évaluation d’une expression
--   Ajoute une méthode `isApplicable` qui retourne un booléen correspondant à l'applicabilité d’une expression (remplace l'éphémère méthode `evaluateApplicability` introduite dans la version précédente)
+-   ⚠ Changement cassant : Les variables manquantes sont désormais retournées sous la forme d’une liste et non plus d’un objet JavaScript
+-   Introduction des variables traversées : les listes des règles qui ont été explorées lors de l’évaluation d’une expression
+-   Ajoute une méthode `isApplicable` qui retourne un booléen correspondant à l’applicabilité d’une expression (remplace l’éphémère méthode `evaluateApplicability` introduite dans la version précédente)
 
 ## 1.0.0-beta.33
 
 **core**
 
--   Ajoute un paramètre `inversionMaxIterations` dans les options à l'instanciation du moteur pour changer le nombre d'itération de l'inversion avant qu'elle ne soit considérée comme "échouée" (par défaut 10).
--   Ajoute une méthode `evaluateApplicability` qui effectue une évaluation partielle d'un nœud pour déterminer son applicabilité. Seules les variables traversées pour déterminer l'applicabilité apparaîssent dans les « variables manquantes »
+-   Ajoute un paramètre `inversionMaxIterations` dans les options à l’instanciation du moteur pour changer le nombre d’itération de l’inversion avant qu’elle ne soit considérée comme ”échouée” (par défaut 10).
+-   Ajoute une méthode `evaluateApplicability` qui effectue une évaluation partielle d’un nœud pour déterminer son applicabilité. Seules les variables traversées pour déterminer l’applicabilité apparaîssent dans les « variables manquantes »
 -   Corrige un bug fatal avec NodeJS v14 ou moins
 
 **publicodes-react**
 
--   Corrige un bug d'affichage dans la documentation lié aux conversions d'unités
+-   Corrige un bug d’affichage dans la documentation lié aux conversions d’unités
 
 ## 1.0.0-beta.32
 
@@ -192,24 +198,24 @@
 
 **publicodes-react**
 
--   La description des mécanismes est disponible via un lien plutôt qu'une modale dans la page
+-   La description des mécanismes est disponible via un lien plutôt qu’une modale dans la page
 -   Amélioration des styles par défaut pour les mécanismes
 -   Suppressions des dépendances à focus-trap-react
 -   Ajout de la visualisation pour le mécanisme texte
--   Répare le style de l'overlay qui s'affiche pour les remplacements #126
+-   Répare le style de l’overlay qui s’affiche pour les remplacements #126
 
 **publicodes**
 
--   Ajoute un nouveau mécanisme `texte` pour l'interpolation de chaine de caractère #152
+-   Ajoute un nouveau mécanisme `texte` pour l’interpolation de chaine de caractère #152
 -   Le formattage des chaine de caractère via `formatValue` ne transforme plus la première lettre en capitale
--   Ajoute la possibilité d'avoir des espaces après une parenthèse dans une expression publicodes
+-   Ajoute la possibilité d’avoir des espaces après une parenthèse dans une expression publicodes
 -   Ajoute la possibilité de définir une expression publicodes sur plusieurs lignes
 
 ## 1.0.0-beta.30
 
 **publicodes-react**
 
--   Correction d'une erreur de runtime JSX manquant dans la version ESModule.
+-   Correction d’une erreur de runtime JSX manquant dans la version ESModule.
 
 ## 1.0.0-beta.29
 
@@ -227,8 +233,8 @@
 
 **publicodes-react**
 
--   Correction d'un type de renderer
--   Le paquet est désormais publié sous forme d'ES Module
+-   Correction d’un type de renderer
+-   Le paquet est désormais publié sous forme d’ES Module
 
 **core**
 
@@ -238,7 +244,7 @@
 
 **publicodes-react**
 
--   ⚠ Changement cassant: `react-markdown` n'est plus utilisé pour afficher les textes. L'utilisateur peut fournir son propre composant de rendu.
+-   ⚠ Changement cassant: `react-markdown` n’est plus utilisé pour afficher les textes. L’utilisateur peut fournir son propre composant de rendu.
 
 ## 1.0.0-beta.25
 
@@ -256,25 +262,25 @@
 
 **core**
 
--   Corrige l'ordre des règles imbriquées dans l'objet parsedRules
+-   Corrige l’ordre des règles imbriquées dans l’objet parsedRules
 
 ## 1.0.0-beta.22
 
 **core**
 
--   Correction: Build en mode "production"
+-   Correction: Build en mode “production”
 
 ## 1.0.0-beta.20
 
 **core**
 
--   Corrige l'omission des types Typescript dans le paquet
+-   Corrige l’omission des types Typescript dans le paquet
 
 ## 1.0.0-beta.19
 
 **core**
 
--   Ajout d'un export `cyclicDependencies` pour permettant de détecter un cycle de références dans les règles
+-   Ajout d’un export `cyclicDependencies` pour permettant de détecter un cycle de références dans les règles
 
 **publicodes-react**
 
@@ -285,23 +291,23 @@
 
 **core**
 
--   Export ESM sans dépendance à d'autres formats de module (UMD)
+-   Export ESM sans dépendance à d’autres formats de module (UMD)
 
 ## 1.0.0-beta.17
 
 **core**
 
--   Prise en compte des variables manquantes pour l'assiette des grilles et barèmes
+-   Prise en compte des variables manquantes pour l’assiette des grilles et barèmes
 
 **publicodes-react**
 
--   Changement cassant : Le composant `<Documentation />` n'est plus exporté
+-   Changement cassant : Le composant `<Documentation />` n’est plus exporté
 -   Nouveau composant exporté `<RulePage />` qui affiche une seule page
--   Possibilité de fournir des composants personnalisés pour l'affichage
+-   Possibilité de fournir des composants personnalisés pour l’affichage
 -   Suppression de la dépendance à react-router et react-helmet
 -   Suppression de dépendences utilitaires : ramda, classnames, react-easy-emoji
 -   Corrige le style du remplacement dans les sommes
--   Corrige l'affichage des règles remplacées
+-   Corrige l’affichage des règles remplacées
 
 ## 1.0.0-beta.16
 
@@ -316,24 +322,24 @@
 
 **core**
 
--   Fix bug sur le mécanisme minimum, une valeur non applicable n'est plus considérée comme valant "0" (#1493)
+-   Fix bug sur le mécanisme minimum, une valeur non applicable n’est plus considérée comme valant “0” (#1493)
 
 ## 1.0.0-beta.14
 
 **publicodes-react**
 
--   Corrige un bug bloquant qui empêchait l'utilisation de la bibliothèque
--   Enlève la dépendance à i18n et react-i18n et toute la traduction qui n'était pas utilisée de toute façon
+-   Corrige un bug bloquant qui empêchait l’utilisation de la bibliothèque
+-   Enlève la dépendance à i18n et react-i18n et toute la traduction qui n’était pas utilisée de toute façon
 -   Ajoute des tests et une publication automatique des paquets publicodes
 
 ## 1.0.0-beta.13
 
 **core**
 
--   Ajout d'un nouveau mécanisme : `résoudre la référence circulaire` (#1472)
--   Simplification de l'API de Engine (#1431)
+-   Ajout d’un nouveau mécanisme : `résoudre la référence circulaire` (#1472)
+-   Simplification de l’API de Engine (#1431)
 
 **publicodes-react**
 
--   Améliore l'affichage des règles virtuelles dépliée dans une somme
+-   Améliore l’affichage des règles virtuelles dépliée dans une somme
 -   Ajoute les meta dans les pages de règles (#1411)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.53",
+	"version": "1.0.0-beta.54",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.53",
+	"version": "1.0.0-beta.54",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/core/source/evaluationUtils.ts
+++ b/packages/core/source/evaluationUtils.ts
@@ -9,7 +9,7 @@ export const collectNodeMissing = (
 
 export const bonus = (missings: Record<string, number> = {}) =>
 	Object.fromEntries(
-		Object.entries(missings).map(([key, value]) => [key, value + 0.0001])
+		Object.entries(missings).map(([key, value]) => [key, value + 1])
 	)
 export const mergeMissing = (
 	left: Record<string, number> | undefined = {},

--- a/packages/core/source/mecanisms/condition.ts
+++ b/packages/core/source/mecanisms/condition.ts
@@ -37,7 +37,7 @@ const evaluate: EvaluationFunction<'condition'> = function (node) {
 		evaluation = condition
 	} else if (condition.nodeValue === undefined) {
 		sinon = this.evaluateNode(node.explanation.sinon)
-		alors = this.evaluateNode(node.explanation.sinon)
+		alors = this.evaluateNode(node.explanation.alors)
 		evaluation = {
 			...condition,
 			missingVariables: mergeAllMissing([sinon, alors]),

--- a/packages/core/source/mecanisms/variablesManquantes.ts
+++ b/packages/core/source/mecanisms/variablesManquantes.ts
@@ -25,12 +25,17 @@ parseVariableManquante.nom = 'variable manquante' as const
 registerEvaluationFunction(parseVariableManquante.nom, function evaluate(node) {
 	const valeur = this.evaluateNode(node.explanation)
 
+	const maxMissingScore = Object.values(valeur.missingVariables).reduce<number>(
+		(a, b) => (a > b ? a : b),
+		0
+	)
+
 	return {
 		...valeur,
 		...node,
 		explanation: valeur,
 		missingVariables: mergeMissing(valeur.missingVariables, {
-			[node.missingVariable]: 1,
+			[node.missingVariable]: maxMissingScore + 1,
 		}),
 	}
 })

--- a/packages/core/test/missingVariables.test.js
+++ b/packages/core/test/missingVariables.test.js
@@ -523,6 +523,4 @@ a . b:
 		expect(result).to.have.keys('a', 'a . b')
 		expect(result['a']).to.be.greaterThan(result['a . b'])
 	})
-
-
 })

--- a/packages/core/test/missingVariables.test.js
+++ b/packages/core/test/missingVariables.test.js
@@ -509,4 +509,20 @@ b . d: c + c + c + c
 		expect(result).to.have.keys('a', 'b . c')
 		expect(result['a']).to.be.greaterThan(result['b . c'])
 	})
+
+	it('Should report missing variable from par défaut with a lesser score', function () {
+		const rawRules = yaml.parse(`
+
+a:
+    par défaut: b
+a . b: 
+    par défaut: 5
+`)
+		const result = new Engine(rawRules).evaluate('a').missingVariables
+
+		expect(result).to.have.keys('a', 'a . b')
+		expect(result['a']).to.be.greaterThan(result['a . b'])
+	})
+
+
 })

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.53",
+	"version": "1.0.0-beta.54",
 	"description": "UI to explore publicodes computations",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Avant : le score de la règle avec le par défaut était à 1, ce qui l'amenait à avoir un score inférieur ou égale aux règles du par défaut.

On souhaite au contraire que la règle apparaisse en premier dans les questions, les questions du par défaut n'étant posée que si on ne sait pas répondre exactement à la question initiale.