### PR TITLE
0 as a default value is allowed

### DIFF
--- a/packages/core/source/rule.ts
+++ b/packages/core/source/rule.ts
@@ -109,7 +109,7 @@ export default function parseRule(
 		}
 
 		// If the `par défaut` value is used, then the rule should be listed as a missingVariables
-		if (ruleValue['par défaut'] || ruleValue['par défaut'] === 0) {
+		if (ruleValue['par défaut'] != null) {
 			ruleValue['par défaut'] = {
 				valeur: ruleValue['par défaut'],
 				'variable manquante': dottedName,

--- a/packages/core/source/rule.ts
+++ b/packages/core/source/rule.ts
@@ -109,7 +109,7 @@ export default function parseRule(
 		}
 
 		// If the `par défaut` value is used, then the rule should be listed as a missingVariables
-		if (ruleValue['par défaut']) {
+		if (ruleValue['par défaut'] || ruleValue['par défaut'] === 0) {
 			ruleValue['par défaut'] = {
 				valeur: ruleValue['par défaut'],
 				'variable manquante': dottedName,

--- a/packages/core/test/missingVariables.test.js
+++ b/packages/core/test/missingVariables.test.js
@@ -523,4 +523,17 @@ a . b:
 		expect(result).to.have.keys('a', 'a . b')
 		expect(result['a']).to.be.greaterThan(result['a . b'])
 	})
+
+	it('Should report missing variable even if default value is 0', function () {
+		const rawRules = yaml.parse(`
+
+
+a: b
+a . b:
+  par défaut: 0
+`)
+		const result = new Engine(rawRules).evaluate('a').missingVariables
+
+		expect(result).to.have.keys('a . b')
+	})
 })


### PR DESCRIPTION
Hello ! 

J'ai repéré un bug en bossant sur NGC, je propose juste cette petite correction mais pas sur que ce soit suffisant ?

Pb: une règle dont la valeur par défaut est 0 n'apparaissait pas dans les missing variables du parent (la question n'est alors pas posée) !

J'ai l'impression que ça correspond à [cette situation](https://publi.codes/studio/d%C3%A9penses-primeur?code=%0A%23+Bienvenue+dans+le+bac+%C3%A0+sable+du+langage+publicode+%21%0A%23+Pour+en+savoir+plus+sur+le+langage+%3A%0A%23+%3D%3E+https%3A%2F%2Fpubli.codes%2Fdocumentation%2Fprincipes-de-base%0A%0Aprix+.+carottes%3A+2%E2%82%AC%2Fkg%0Aprix+.+champignons%3A+5%E2%82%AC%2Fkg%0Aprix+.+avocat%3A%0A++question%3A+combien+%3F%0A++par+d%C3%A9faut%3A+0%0A%0Ad%C3%A9penses+primeur%3A%0A++somme%3A%0A++++-+prix+.+carottes+*+1.5+kg%0A++++-+prix+.+champignons+*+500g%0A++++-+prix+.+avocat+*+3+avocat) 

Testé en local, j'ai bien les questions dans les missing variables et qui s'affichent donc à l'écran

ping @laem 