### PR TITLE
Amélioration du menu de navigation de la documentation

### DIFF
--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -87,6 +87,8 @@ type RuleProps = {
 	apiDocumentationUrl?: string
 	apiEvaluateUrl?: string
 	npmPackage?: string
+	mobileMenuPortalId?: string
+	openNavButtonPortalId?: string
 }
 
 function Rule({
@@ -97,6 +99,8 @@ function Rule({
 	apiDocumentationUrl,
 	apiEvaluateUrl,
 	npmPackage,
+	mobileMenuPortalId,
+	openNavButtonPortalId,
 }: RuleProps) {
 	const baseEngine = useEngine()
 	const { References, Text } = useContext(RenderersContext)
@@ -121,7 +125,11 @@ function Rule({
 
 	return (
 		<Container id="documentationRuleRoot">
-			<RulesNav dottedName={dottedName} />
+			<RulesNav
+				dottedName={dottedName}
+				mobileMenuPortalId={mobileMenuPortalId}
+				openNavButtonPortalId={openNavButtonPortalId}
+			/>
 			<Article>
 				<DottedNameContext.Provider value={dottedName}>
 					{useSubEngine && (

--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -124,7 +124,7 @@ function Rule({
 	const { valeur, nullableParent, ruleDisabledByItsParent } = rule.explanation
 
 	return (
-		<Container id="documentationRuleRoot">
+		<Container id="documentation-rule-root">
 			<RulesNav
 				dottedName={dottedName}
 				mobileMenuPortalId={mobileMenuPortalId}

--- a/packages/react-ui/source/rule/RulesNav.tsx
+++ b/packages/react-ui/source/rule/RulesNav.tsx
@@ -7,9 +7,15 @@ import { useEngine } from '../hooks'
 import { RuleLinkWithContext } from '../RuleLink'
 interface Props {
 	dottedName: string
+	mobileMenuPortalId?: string
+	openNavButtonPortalId?: string
 }
 
-export const RulesNav = ({ dottedName }: Props) => {
+export const RulesNav = ({
+	dottedName,
+	mobileMenuPortalId,
+	openNavButtonPortalId,
+}: Props) => {
 	const baseEngine = useEngine()
 	const [navOpen, setNavOpen] = useState(false)
 
@@ -43,8 +49,12 @@ export const RulesNav = ({ dottedName }: Props) => {
 		)
 	}, [])
 
-	return (
-		<>
+	const openNavButtonPortalElement =
+		(openNavButtonPortalId && document.getElementById(openNavButtonPortalId)) ||
+		document.getElementById('rules-nav-open-nav-button')
+
+	const menu = (
+		<Container $open={navOpen}>
 			<Background
 				$open={navOpen}
 				onClick={() => {
@@ -53,12 +63,12 @@ export const RulesNav = ({ dottedName }: Props) => {
 			/>
 
 			{/* Portal in Header */}
-			{document.getElementById('rules-nav-open-nav-button') &&
+			{openNavButtonPortalElement &&
 				ReactDOM.createPortal(
 					<OpenNavButton onClick={() => setNavOpen(true)}>
 						Toutes les règles
 					</OpenNavButton>,
-					document.getElementById('rules-nav-open-nav-button')
+					openNavButtonPortalElement
 				)}
 
 			<Nav $open={navOpen}>
@@ -89,8 +99,20 @@ export const RulesNav = ({ dottedName }: Props) => {
 						})}
 				</ul>
 			</Nav>
-		</>
+		</Container>
 	)
+
+	const isMobileMenu = window.matchMedia(
+		`(max-width: ${breakpointsWidth.lg})`
+	).matches
+
+	const mobileMenuPortalElement = mobileMenuPortalId
+		? document.getElementById(mobileMenuPortalId)
+		: null
+
+	return isMobileMenu && mobileMenuPortalElement
+		? ReactDOM.createPortal(menu, mobileMenuPortalElement)
+		: menu
 }
 
 const NavLi = ({ ruleDottedName, open, active, onClickDropdown }) => {
@@ -146,6 +168,18 @@ export const breakpointsWidth = {
 	xl: '1200px',
 }
 
+const Container = styled.div<{ $open: boolean }>`
+	z-index: 200;
+	overflow: auto;
+	position: sticky;
+	top: 0;
+
+	@media (min-width: ${breakpointsWidth.lg}) {
+		max-width: 50%;
+		flex-shrink: 0;
+	}
+`
+
 const Background = styled.div<{ $open: boolean }>`
 	background: rgb(0 0 0 / 25%);
 	position: fixed;
@@ -184,7 +218,6 @@ const OpenNavButton = styled.button`
 
 const Nav = styled.nav<{ $open: boolean }>`
 	@media (min-width: ${breakpointsWidth.lg}) {
-		max-width: 50%;
 		flex-shrink: 0;
 	}
 	border-right: 1px solid #e6e6e6;
@@ -207,6 +240,7 @@ const Nav = styled.nav<{ $open: boolean }>`
 		transition: all ease-in-out 0.25s;
 		${({ $open }) => ($open ? '' : 'transform: translateX(-100%);')}
 	}
+
 	ul {
 		flex-wrap: nowrap;
 		margin: 0;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -23,3 +23,7 @@
 	margin: 0 calc(-1 * var(--ifm-pre-padding));
 	padding: 0 var(--ifm-pre-padding);
 }
+
+#documentation-rule-root .dropdown {
+	display: flex;
+}


### PR DESCRIPTION
- Ajout de la props optionnelle `openNavButtonPortalId` qui permet de changer la place du bouton pour ouvrir le menu sur mobile
- Ajout de la props optionnelle `mobileMenuPortalId` qui permet de changer la place du menu mobile
- Renomage de l'id de la doc `documentationRuleRoot` par `documentation-rule-root`
- fix #277 