### PR TITLE
Hide dev section of the doc in the tuto

### DIFF
--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -35,6 +35,7 @@ type RulePageProps = {
 	npmPackage?: string
 	mobileMenuPortalId?: string
 	openNavButtonPortalId?: string
+	showDevSection?: boolean
 }
 
 export default function RulePage({
@@ -48,6 +49,7 @@ export default function RulePage({
 	npmPackage,
 	mobileMenuPortalId,
 	openNavButtonPortalId,
+	showDevSection = true,
 }: RulePageProps) {
 	const currentEngineId = new URLSearchParams(window.location.search).get(
 		'currentEngineId'
@@ -78,6 +80,7 @@ export default function RulePage({
 						npmPackage={npmPackage}
 						mobileMenuPortalId={mobileMenuPortalId}
 						openNavButtonPortalId={openNavButtonPortalId}
+						showDevSection={showDevSection}
 					/>
 				</RenderersContext.Provider>
 			</BasepathContext.Provider>
@@ -88,13 +91,16 @@ export default function RulePage({
 type RuleProps = {
 	dottedName: string
 	subEngineId?: number
-	language: RulePageProps['language']
-	apiDocumentationUrl?: string
-	apiEvaluateUrl?: string
-	npmPackage?: string
-	mobileMenuPortalId?: string
-	openNavButtonPortalId?: string
-}
+} & Pick<
+	RulePageProps,
+	| 'language'
+	| 'apiDocumentationUrl'
+	| 'apiEvaluateUrl'
+	| 'npmPackage'
+	| 'mobileMenuPortalId'
+	| 'openNavButtonPortalId'
+	| 'showDevSection'
+>
 
 function Rule({
 	dottedName,
@@ -105,6 +111,7 @@ function Rule({
 	npmPackage,
 	mobileMenuPortalId,
 	openNavButtonPortalId,
+	showDevSection,
 }: RuleProps) {
 	const baseEngine = useEngine()
 	const { References, Text } = useContext(RenderersContext)
@@ -208,21 +215,25 @@ function Rule({
 					)}
 					<br />
 
-					<h3>Informations pour les développeurs</h3>
-					<Text>
-						Vous trouverez ci-dessous des informations techniques qui peuvent
-						être utiles aux développeurs
-					</Text>
-
-					<DeveloperAccordion
-						engine={engine}
-						situation={situation}
-						dottedName={dottedName}
-						rule={rule}
-						apiDocumentationUrl={apiDocumentationUrl}
-						apiEvaluateUrl={apiEvaluateUrl}
-						npmPackage={npmPackage}
-					></DeveloperAccordion>
+					{showDevSection && (
+						<>
+							<h3>Informations techniques</h3>
+							<Text>
+								Si vous êtes développeur/euse vous trouverez ci-dessous des
+								informations techniques utiles pour l'intégration de cette règle
+								dans votre application.
+							</Text>
+							<DeveloperAccordion
+								engine={engine}
+								situation={situation}
+								dottedName={dottedName}
+								rule={rule}
+								apiDocumentationUrl={apiDocumentationUrl}
+								apiEvaluateUrl={apiEvaluateUrl}
+								npmPackage={npmPackage}
+							></DeveloperAccordion>
+						</>
+					)}
 				</DottedNameContext.Provider>
 			</Article>
 		</Container>

--- a/website/src/components/Documentation.tsx
+++ b/website/src/components/Documentation.tsx
@@ -15,6 +15,7 @@ type ResultsProps = {
 	defaultTarget?: string
 	onTargetChange?: (target: string) => void
 	baseUrl?: string
+	showDevSection?: boolean
 }
 
 class Logger {
@@ -50,6 +51,7 @@ export default function Documentation({
 	defaultTarget = '',
 	onTargetChange,
 	baseUrl,
+	showDevSection,
 }: ResultsProps) {
 	const logger = useMemo(() => new Logger(), [rules])
 	const engine = useMemo(
@@ -112,6 +114,7 @@ export default function Documentation({
 					rulePath={ruleToPaths[currentTarget]?.replace(/^\//, '') || ''}
 					engine={engine}
 					documentationPath={''}
+					showDevSection={showDevSection}
 					renderers={{
 						Link: ({ to, children }) => {
 							return (

--- a/website/src/components/Playground.tsx
+++ b/website/src/components/Playground.tsx
@@ -34,6 +34,7 @@ export default function Playground({
 					rules={children}
 					defaultTarget={defaultTarget}
 					onTargetChange={onTargetChange}
+					showDevSection={false}
 				/>
 				<div style={{ paddingBottom: '1rem' }} />
 			</ErrorBoundary>


### PR DESCRIPTION
The dev section is unnecessary in the tutorial, and it adds visual complexity while trying to understand the language :

![image](https://user-images.githubusercontent.com/1730702/203371245-09443aa6-6f28-4c9a-8f38-c72d31f8d422.png)

This PR create an option `showDevSection` true by default, that is used to hide this section in the tutorial.