### PR TITLE
Correctifs RGAA 

### DIFF
--- a/packages/react-ui/source/PublicodesBlock.tsx
+++ b/packages/react-ui/source/PublicodesBlock.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styled from 'styled-components'
 
 export default function PublicodesBlock({ source }: { source: string }) {
@@ -15,8 +16,12 @@ export default function PublicodesBlock({ source }: { source: string }) {
 			<LaunchButton
 				href={`${baseURL}/studio?code=${encodeURIComponent(source)}`}
 				target="_blank"
+				aria-label="Lancer le calcul, ouvrir dans le studio Publicodes, nouvelle fenêtre"
 			>
-				⚡ Lancer le calcul
+				<span role="img" aria-hidden>
+					⚡
+				</span>{' '}
+				Lancer le calcul
 			</LaunchButton>
 		</div>
 	)

--- a/packages/react-ui/source/PublicodesBlock.tsx
+++ b/packages/react-ui/source/PublicodesBlock.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 export default function PublicodesBlock({ source }: { source: string }) {

--- a/packages/react-ui/source/PublicodesBlock.tsx
+++ b/packages/react-ui/source/PublicodesBlock.tsx
@@ -17,10 +17,7 @@ export default function PublicodesBlock({ source }: { source: string }) {
 				target="_blank"
 				aria-label="Lancer le calcul, ouvrir dans le studio Publicodes, nouvelle fenêtre"
 			>
-				<span role="img" aria-hidden>
-					⚡
-				</span>{' '}
-				Lancer le calcul
+				<span aria-hidden>⚡</span> Lancer le calcul
 			</LaunchButton>
 		</div>
 	)

--- a/packages/react-ui/source/component/Accordion.tsx
+++ b/packages/react-ui/source/component/Accordion.tsx
@@ -9,7 +9,7 @@ const AccordionContainer = styled.div`
 	border: 1px solid #bbb;
 `
 
-const H3 = styled.h3`
+const H4 = styled.h4`
 	font-size: 16px;
 	font-weight: 700;
 	margin: 2rem 0px 1rem;
@@ -46,7 +46,7 @@ const AccordionWrapper = styled.div<{ i: number }>`
 			border-top-width: 1px;
 		`}
 
-	& ${H3} {
+	& ${H4} {
 		margin: 0;
 	}
 `
@@ -82,12 +82,12 @@ export const Accordion = ({ items }: AccordionProps) => {
 		<AccordionContainer>
 			{items.map(({ id, title, children }, i) => (
 				<AccordionWrapper id={id} key={id} i={i}>
-					<H3>
+					<H4>
 						<button onClick={toggleAccordion(i)}>
 							<span>{title}</span>
 							<StyledArrow $isOpen={open[i]} />
 						</button>
-					</H3>
+					</H4>
 					<div>
 						<Child open={!!open[i]}>{children}</Child>
 					</div>

--- a/packages/react-ui/source/mecanisms/Operation.tsx
+++ b/packages/react-ui/source/mecanisms/Operation.tsx
@@ -9,7 +9,8 @@ export default function Operation({ nodeValue, explanation, operator, unit }) {
 		explanation[0].nodeKind === 'constant'
 
 	return (
-		<StyledOperation className="operation">
+		<StyledOperation className="operation" role="math">
+			<span>(</span>
 			{!isUnaryOperation && (
 				<>
 					<Explanation node={explanation[0]} />
@@ -24,6 +25,7 @@ export default function Operation({ nodeValue, explanation, operator, unit }) {
 					<NodeValuePointer data={nodeValue} unit={unit} />
 				</span>
 			)}
+			<span>)</span>
 		</StyledOperation>
 	)
 }
@@ -32,15 +34,9 @@ const StyledOperation = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.125rem;
-	::before {
-		content: '(';
-	}
 	> .operation ::before,
 	> .operation ::after {
 		content: '';
-	}
-	::after {
-		content: ')';
 	}
 	.result {
 		margin-left: 0.2rem;

--- a/packages/react-ui/source/mecanisms/Reference.tsx
+++ b/packages/react-ui/source/mecanisms/Reference.tsx
@@ -38,7 +38,7 @@ export default function Reference(
 				maxWidth: '100%',
 			}}
 		>
-			<span
+			<div
 				style={{
 					display: 'flex',
 					alignItems: 'baseline',
@@ -54,6 +54,11 @@ export default function Reference(
 							<UnfoldButton
 								onClick={() => setFolded(!folded)}
 								aria-expanded={!folded}
+								aria-label={
+									folded
+										? 'Déplier, afficher le détail'
+										: 'Replier, afficher le détail'
+								}
 							>
 								{folded ? 'Déplier' : 'Replier'}
 							</UnfoldButton>
@@ -65,7 +70,7 @@ export default function Reference(
 						<NodeValuePointer data={nodeValue} unit={unit} />
 					)}
 				</div>
-			</span>{' '}
+			</div>{' '}
 			{!folded && (
 				<div>
 					<UnfoldIsEnabledContext.Provider value={false}>

--- a/packages/react-ui/source/mecanisms/Reference.tsx
+++ b/packages/react-ui/source/mecanisms/Reference.tsx
@@ -51,8 +51,11 @@ export default function Reference(
 				<div style={{ flex: 1, display: 'flex', alignItems: 'baseline' }}>
 					{isFoldEnabled && (
 						<>
-							<UnfoldButton onClick={() => setFolded(!folded)}>
-								{folded ? 'déplier' : 'replier'}
+							<UnfoldButton
+								onClick={() => setFolded(!folded)}
+								aria-expanded={!folded}
+							>
+								{folded ? 'Déplier' : 'Replier'}
 							</UnfoldButton>
 							<StyledGuide />
 						</>

--- a/packages/react-ui/source/mecanisms/Situation.tsx
+++ b/packages/react-ui/source/mecanisms/Situation.tsx
@@ -8,7 +8,7 @@ export default function MecanismSituation({ sourceMap }) {
 	const engine = useContext(EngineContext)
 	const situationValeur = engine?.evaluate(sourceMap.args['dans la situation'])
 	return situationValeur?.nodeValue !== undefined ? (
-		<InfixMecanism prefixed value={sourceMap.args['valeur']} dimValue>
+		<InfixMecanism prefixed value={sourceMap.args['valeur']}>
 			<p>
 				<strong>Valeur renseignée dans la simulation : </strong>
 				<Explanation node={(situationValeur as RuleNode).explanation.valeur} />

--- a/packages/react-ui/source/mecanisms/common.tsx
+++ b/packages/react-ui/source/mecanisms/common.tsx
@@ -76,7 +76,7 @@ export function Mecanism({
 	displayName = true,
 }: NodeProps) {
 	return (
-		<StyledMecanism name={name}>
+		<StyledMecanism mecanismName={name}>
 			{displayName && <MecanismName name={name}>{name}</MecanismName>}
 			<div>
 				{children}
@@ -167,7 +167,7 @@ const MecanismName = ({
 	)
 }
 
-const StyledMecanism = styled.div<{ name: string }>`
+const StyledMecanism = styled.div<{ mecanismName: string }>`
 	border: 1px solid;
 	max-width: 100%;
 	border-radius: 3px;
@@ -177,7 +177,7 @@ const StyledMecanism = styled.div<{ name: string }>`
 	flex: 1;
 	flex-direction: column;
 	text-align: left;
-	border-color: ${({ name }) => mecanismColors(name)};
+	border-color: ${({ mecanismName }) => mecanismColors(mecanismName)};
 	.properties > li {
 		margin: 1rem 0;
 	}

--- a/packages/react-ui/source/mecanisms/common.tsx
+++ b/packages/react-ui/source/mecanisms/common.tsx
@@ -101,12 +101,10 @@ export const InfixMecanism = ({
 	value,
 	prefixed,
 	children,
-	dimValue,
 }: {
 	value: EvaluatedNode
 	children: React.ReactNode
 	prefixed?: boolean
-	dimValue?: boolean
 }) => {
 	return (
 		<div>
@@ -117,24 +115,12 @@ export const InfixMecanism = ({
 					position: 'relative',
 				}}
 			>
-				{dimValue && <DimOverlay />}
 				<Explanation node={value} />
 			</div>
 			{!prefixed && children}
 		</div>
 	)
 }
-const DimOverlay = styled.div`
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	right: 0;
-	background-color: white;
-	left: 0;
-	opacity: 0.5;
-	pointer-events: none;
-	z-index: 1;
-`
 
 export const InlineMecanismName = ({ name }: { name: string }) => {
 	return (

--- a/packages/react-ui/source/rule/DeveloperAccordion.tsx
+++ b/packages/react-ui/source/rule/DeveloperAccordion.tsx
@@ -185,6 +185,9 @@ function ActualSituation({
 	)
 }
 
+const LINK_NPM_LABEL = 'Retrouvez ce paquet sur NPM'
+const LINK_PUBLICODES_LABEL = 'moteur Publicodes'
+
 function PackageUsage({
 	rule,
 	situation,
@@ -220,27 +223,29 @@ console.log(formatValue(evaluation))
 			<p>
 				Vous pouvez installer notre package de règles pour l'utiliser avec le{' '}
 				<Link
-					aria-label="moteur Publicodes, accéder au site publi.codes, nouvelle fenêtre"
+					aria-label={`${LINK_PUBLICODES_LABEL}, accéder au site publi.codes, nouvelle fenêtre`}
 					href="https://publi.codes/"
 				>
-					moteur Publicodes
+					{LINK_PUBLICODES_LABEL}
 				</Link>{' '}
 				et ainsi effectuer vos propres calculs. Voici un exemple avec votre
-				situation et la règle actuelle :
+				situation et la règle actuelle :
 			</p>
 			<Code tabs={tabs} />
 
 			<p style={{ textAlign: 'right' }}>
 				<Link
 					href={'https://www.npmjs.com/package/' + npmPackage}
-					aria-label="Retrouvez ce paquet sur NPM, accéder à la page npm du package Publicodes, nouvelle fenêtre"
+					aria-label={`${LINK_NPM_LABEL}, accéder à la page npm du package Publicodes, nouvelle fenêtre`}
 				>
-					<span aria-hidden>📦</span> Retrouvez ce paquet sur NPM
+					<span aria-hidden>📦</span> {LINK_NPM_LABEL}
 				</Link>
 			</p>
 		</section>
 	)
 }
+
+const LINK_API_LABEL = 'En savoir plus sur notre API REST'
 
 function ApiUsage({
 	situation,
@@ -288,9 +293,9 @@ console.log(evaluate)`,
 				<p style={{ textAlign: 'right' }}>
 					<Link
 						to={apiDocumentationUrl}
-						aria-label="En savoir plus sur notre API REST, accéder à la documentation, nouvelle fenêtre"
+						aria-label={`${LINK_API_LABEL}, accéder à la documentation, nouvelle fenêtre`}
 					>
-						<span aria-hidden>👩‍💻</span> En savoir plus sur notre API REST
+						<span aria-hidden>👩‍💻</span> {LINK_API_LABEL}
 					</Link>
 				</p>
 			)}

--- a/packages/react-ui/source/rule/DeveloperAccordion.tsx
+++ b/packages/react-ui/source/rule/DeveloperAccordion.tsx
@@ -219,21 +219,23 @@ console.log(formatValue(evaluation))
 			<h5>Lancer un calcul avec Publicodes</h5>
 			<p>
 				Vous pouvez installer notre package de règles pour l'utiliser avec le{' '}
-				<Link href="https://publi.codes/">moteur Publicodes</Link> et ainsi
-				effectuer vos propres calculs. Voici un exemple avec votre situation et
-				la règle actuelle :
+				<Link
+					aria-label="moteur Publicodes, accéder au site publi.codes, nouvelle fenêtre"
+					href="https://publi.codes/"
+				>
+					moteur Publicodes
+				</Link>{' '}
+				et ainsi effectuer vos propres calculs. Voici un exemple avec votre
+				situation et la règle actuelle :
 			</p>
 			<Code tabs={tabs} />
 
 			<p style={{ textAlign: 'right' }}>
 				<Link
 					href={'https://www.npmjs.com/package/' + npmPackage}
-					aria-label="Retrouvez ce paquet sur NPM, accéder à la page informative du package Publicodes, nouvelle fenêtre"
+					aria-label="Retrouvez ce paquet sur NPM, accéder à la page npm du package Publicodes, nouvelle fenêtre"
 				>
-					<span role="img" aria-hidden>
-						📦
-					</span>{' '}
-					Retrouvez ce paquet sur NPM
+					<span aria-hidden>📦</span> Retrouvez ce paquet sur NPM
 				</Link>
 			</p>
 		</section>
@@ -288,10 +290,7 @@ console.log(evaluate)`,
 						to={apiDocumentationUrl}
 						aria-label="En savoir plus sur notre API REST, accéder à la documentation, nouvelle fenêtre"
 					>
-						<span role="img" aria-hidden>
-							👩‍💻
-						</span>{' '}
-						En savoir plus sur notre API REST
+						<span aria-hidden>👩‍💻</span> En savoir plus sur notre API REST
 					</Link>
 				</p>
 			)}

--- a/packages/react-ui/source/rule/DeveloperAccordion.tsx
+++ b/packages/react-ui/source/rule/DeveloperAccordion.tsx
@@ -226,8 +226,14 @@ console.log(formatValue(evaluation))
 			<Code tabs={tabs} />
 
 			<p style={{ textAlign: 'right' }}>
-				<Link href={'https://www.npmjs.com/package/' + npmPackage}>
-					📦 Retrouvez ce paquet sur NPM
+				<Link
+					href={'https://www.npmjs.com/package/' + npmPackage}
+					aria-label="Retrouvez ce paquet sur NPM, accéder à la page informative du package Publicodes, nouvelle fenêtre"
+				>
+					<span role="img" aria-hidden>
+						📦
+					</span>{' '}
+					Retrouvez ce paquet sur NPM
 				</Link>
 			</p>
 		</section>
@@ -278,8 +284,14 @@ console.log(evaluate)`,
 			<Code tabs={tabs} />
 			{apiDocumentationUrl && (
 				<p style={{ textAlign: 'right' }}>
-					<Link to={apiDocumentationUrl}>
-						👩‍💻 En savoir plus sur notre API REST
+					<Link
+						to={apiDocumentationUrl}
+						aria-label="En savoir plus sur notre API REST, accéder à la documentation, nouvelle fenêtre"
+					>
+						<span role="img" aria-hidden>
+							👩‍💻
+						</span>{' '}
+						En savoir plus sur notre API REST
 					</Link>
 				</p>
 			)}

--- a/packages/react-ui/source/rule/DeveloperAccordion.tsx
+++ b/packages/react-ui/source/rule/DeveloperAccordion.tsx
@@ -146,7 +146,7 @@ function ActualRule({
 
 	return (
 		<section>
-			<h4>Règle actuelle</h4>
+			<h5>Règle actuelle</h5>
 			<Code tabs={{ dottedName }} />
 			<RuleSource dottedName={dottedName} engine={engine} />
 		</section>
@@ -168,7 +168,7 @@ function ActualSituation({
 
 	return (
 		<section>
-			<h4>Situation actuelle</h4>
+			<h5>Situation actuelle</h5>
 			{keys.length ? (
 				<p>
 					Voici les données que vous avez saisies dans notre simulateur sous
@@ -216,7 +216,7 @@ console.log(formatValue(evaluation))
 
 	return (
 		<section>
-			<h4>Lancer un calcul avec Publicodes</h4>
+			<h5>Lancer un calcul avec Publicodes</h5>
 			<p>
 				Vous pouvez installer notre package de règles pour l'utiliser avec le{' '}
 				<Link href="https://publi.codes/">moteur Publicodes</Link> et ainsi
@@ -270,7 +270,7 @@ console.log(evaluate)`,
 
 	return (
 		<section>
-			<h4>Utiliser notre API REST</h4>
+			<h5>Utiliser notre API REST</h5>
 			<p>
 				Vous trouverez ici un exemple d'utilisation de notre API REST via curl
 				ou un fetch javascript.
@@ -290,7 +290,7 @@ console.log(evaluate)`,
 function MissingVars({ selfMissing }: { selfMissing: string[] }) {
 	return (
 		<section>
-			<h4>Données manquantes</h4>
+			<h5>Données manquantes</h5>
 			{!!selfMissing?.length ? (
 				<>
 					<p>
@@ -339,7 +339,7 @@ function ReverseMissing({
 
 	return (
 		<section>
-			<h4>Règles qui ont besoin de cette valeur</h4>
+			<h5>Règles qui ont besoin de cette valeur</h5>
 
 			{ruleNamesWithMissing.length ? (
 				<>
@@ -390,7 +390,7 @@ function Effect({
 	return (
 		<>
 			<section>
-				<h4>Effets sur d'autres règles</h4>
+				<h5>Effets sur d'autres règles</h5>
 				{!!replacements.length ? (
 					<>
 						<p>
@@ -414,7 +414,7 @@ function Effect({
 			</section>
 
 			<section>
-				<h4>Règles qui peuvent avoir un effet sur cette valeur</h4>
+				<h5>Règles qui peuvent avoir un effet sur cette valeur</h5>
 				{effects.length ? (
 					<>
 						<p>

--- a/packages/react-ui/source/rule/Header.tsx
+++ b/packages/react-ui/source/rule/Header.tsx
@@ -23,7 +23,7 @@ export default function RuleHeader({ dottedName }) {
 					.map((parentDottedName) => (
 						<span key={parentDottedName}>
 							<RuleLinkWithContext dottedName={parentDottedName} displayIcon />
-							{' › '}
+							<span aria-hidden>{' › '}</span>
 						</span>
 					))}
 			</div>

--- a/packages/react-ui/source/rule/RuleSource.tsx
+++ b/packages/react-ui/source/rule/RuleSource.tsx
@@ -11,10 +11,19 @@ export default function RuleSource({ engine, dottedName }: Props) {
 		return null
 	}
 
+	const linkLabel = 'Afficher la règle dans le bac à sable Publicodes'
+
 	return (
 		<p style={{ textAlign: 'right' }}>
-			<a target="_blank" href={href}>
-				✍️ Voir la règle dans le bac à sable Publicodes
+			<a
+				target="_blank"
+				href={href}
+				aria-label={`${linkLabel}, nouvelle fenêtre`}
+			>
+				<span role="img" aria-hidden>
+					✍️
+				</span>{' '}
+				{linkLabel}
 			</a>
 		</p>
 	)

--- a/packages/react-ui/source/rule/RuleSource.tsx
+++ b/packages/react-ui/source/rule/RuleSource.tsx
@@ -20,10 +20,7 @@ export default function RuleSource({ engine, dottedName }: Props) {
 				href={href}
 				aria-label={`${linkLabel}, nouvelle fenêtre`}
 			>
-				<span role="img" aria-hidden>
-					✍️
-				</span>{' '}
-				{linkLabel}
+				<span aria-hidden>✍️</span> {linkLabel}
 			</a>
 		</p>
 	)


### PR DESCRIPTION
Points corrigés : 
* phrases incluant des emojis : les emojis sont dissimulés aux lecteurs d'écran
* ajout d' `aria-label` précisant l'action de certains liens
* révision de la hiérarchisation de certaines balises `<hx>`
* affiche les parenthèses en JSX (précédemment en CSS)
* modifie certaines balises `<span>` > `<div>` pour se conformer au validateur W3C
* retire `DimOverlay` qui nuisait à l'accessibilité des couleurs (contrastes)
* ajout d'attributs `aria-expanded` sur les boutons "Déplier/Replier"