### PR TITLE
Remove iife format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **core**
 
 -   **⚠ Changement cassant :** exception en cas de division par 0 dans un mécanisme.
+-   **⚠ Changement cassant :** plus de publication du paquet au format obsolète "iife"
 
 ## 1.0.0-beta.61
 

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
 	entry: ['source/index.ts'],
-	format: ['cjs', 'esm', 'iife'],
-	globalName: 'publicodes',
+	format: ['cjs', 'esm'],
 	sourcemap: true,
 	clean: true,
 	dts: true,

--- a/website/docs/tutoriel.mdx
+++ b/website/docs/tutoriel.mdx
@@ -27,7 +27,6 @@ Voici comment importer publicodes en fonction de l'environnement.
     values={[
     	{ label: 'esmodule', value: 'esmodule' },
     	{ label: 'commonJS', value: 'commonJS' },
-    	{ label: 'Deno', value: 'esmodule-unpkg' },
     	{ label: 'Navigateur', value: 'script-unpkg' },
     ]}
 >
@@ -47,13 +46,6 @@ Si vous utilisez une version de node < `15.0.0`
 
 ```js
 const Engine = require('publicodes').default
-```
-
-</TabItem>
-<TabItem value="esmodule-unpkg">
-
-```js
-import Engine from 'https://unpkg.com/publicodes@next/esm/index.global.js'
 ```
 
 </TabItem>
@@ -78,7 +70,7 @@ jeu de règles publicodes.
 
 ```js
 import Engine from 'publicodes'
-import {parse} from 'yaml'
+import { parse } from 'yaml'
 
 // On définit une liste de règles publicodes
 const rules = `
@@ -94,7 +86,7 @@ dépenses primeur:
       - prix . champignons * 500g
       - prix . avocat * 3 avocat
 `
-// publicodes ne prend plus en entrée du YAML, vous devez parser vous-même votre code source 
+// publicodes ne prend plus en entrée du YAML, vous devez parser vous-même votre code source
 const parsedRules = parse(rules)
 
 // On initialise un moteur en lui donnant le publicodes sous forme d'objet javascript.
@@ -102,15 +94,13 @@ const parsedRules = parse(rules)
 const engine = new Engine(parsedRules)
 ```
 
+Pourquoi ne pas accepter du YAML en entrée de publicodes, alors que cette syntaxe est effectivement plus agréable que du JSON ?
 
-Pourquoi ne pas accepter du YAML en entrée de publicodes, alors que cette syntaxe est effectivement plus agréable que du JSON ? 
-
-Parce que l'étape de parsing du YAML nécessite d'embarquer une lourde bibliothèque. 
+Parce que l'étape de parsing du YAML nécessite d'embarquer une lourde bibliothèque.
 Libre ainsi à chaque projet de faire cette étape au moment et à l'endroit le plus adapté, côté serveur ou lors du build de l’application
 
 > Il est donc également tout à fait possible d'initialiser `Engine` avec un objet JSON, il suffit de le parser avec la fonction native `JSON.parse(monJSON)`.
 > Le JSON étant le langage dominant des APIs (on n'échange jamais de YAML par API), c'est un moyen en pratique courant de le faire.
-
 
 La variable `engine` permet en ensuite de calculer la valeur d'une règle avec la
 méthode `evaluate` :
@@ -189,8 +179,8 @@ apparaîtra dans la propriété `missingVariables` :
 
 ```js
 const missingYEngine = new Engine({
-		x: 'y + 5',
-		y: null
+	x: 'y + 5',
+	y: null,
 })
 
 console.log(missingYEngine.evaluate('x').missingVariables)


### PR DESCRIPTION
The initial need was to use "publicodes" directly in the browser without using a bundler or a package manager. The documentation now reference the following snippet to run publicodes directly in the browser:

```html
<script src="https://unpkg.com/publicodes@next/dist/index.global.js"></script>
<script>
    const Engine = window.publicodes.default
</script>
```