### PR TITLE
docs: correction

### DIFF
--- a/website/docs/principes-de-base.mdx
+++ b/website/docs/principes-de-base.mdx
@@ -21,8 +21,7 @@ prix d'un repas: 10 €
 prix total: 5 * prix d'un repas
 ```
 
-Il s'agit d'un langage déclaratif : comme dans une formule d'un tableur le `prix total` sera recalculé automatiquement si le prix d'un repas change. L'ordre de
-définition des règles n'a pas d'importance.
+Il s'agit d'un langage déclaratif : comme dans une formule d'un tableur le `prix total` sera recalculé automatiquement si le prix d'un repas change.
 
 ## Unités
 


### PR DESCRIPTION
> L'ordre de définition des règles n'a pas d'importance.

J'ai l'impression que ceci n'est pas vrai

Exemple : https://publi.codes/studio/resultat2?code=%0Ax%3A+oui%0Ay%3A+oui%0A%0Aa%3A+oui%0A%0A%23+ce+bloc+n%27est+applicable+que+s%27il+apparait+avant+le+bloc+a+.+b%0Aa+.+x+.+y%3A%0A++remplace%3A+resultat%0A++applicable+si%3A+y+%3D+oui%0A++texte%3A+%22a.x.y%22%0A%0Aa+.+x%3A%0A++remplace%3A+resultat%0A++applicable+si%3A+x+%3D+oui%0A++texte%3A+%22a.x%22%0A%0Aresultat%3A+oui%0A%23+hack+to+see+the+change%0Aresultat2%3A+resultat%0A%0A



