### PR TITLE
Update to 1.0.0-beta.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## next
 
+## 1.0.0-beta.66
+**publicodes-react**
+- Fix the display of explanations in the context of a recalul mecanism (the computed values where those of the base engine before)
+
+**core**
+- Recalcul mecanism now use the initial context to compute the values of overrides, instead of using the new one.
+
 ## 1.0.0-beta.65
 
 **publicodes-react**
@@ -49,13 +56,13 @@
 **core**
 
 -   **⚠ Changement cassant :** exception en cas de division par 0 dans un mécanisme.
--   **⚠ Changement cassant :** plus de publication du paquet au format obsolète "iife"
+-   **⚠ Changement cassant :** plus de publication du paquet au format obsolète “iife”
 
 **publicodes-react**
 
 -   Refacto publicodes-react to esm
 -   Refacto in RuleLink
--   Temporary fix bad babel transformation on [...new Set()]]
+-   Temporary fix bad babel transformation on […new Set()]]
 -   Fix publicodes-react missing sourcemap
 
 **website**

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.65",
+	"version": "1.0.0-beta.66",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.65",
+	"version": "1.0.0-beta.66",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/core/source/mecanisms/recalcul.ts
+++ b/packages/core/source/mecanisms/recalcul.ts
@@ -31,7 +31,10 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 						serializeUnit(replacementEvaluation.unit)
 				)
 			})
-			.map(([originRule, replacement]) => [originRule.dottedName, replacement])
+			.map(
+				([originRule, replacement]) =>
+					[originRule.dottedName, replacement] as [string, ASTNode]
+			)
 	)
 
 	let engine = this
@@ -40,6 +43,12 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 			keepPreviousSituation: true,
 		})
 		engine.subEngineId = this.subEngines.length
+
+		// The value of the replaced ruled are computed **without the replacement active**
+		Object.values(amendedSituation).forEach((value) =>
+			engine.cache.nodes.set(value, this.evaluate(value))
+		)
+
 		this.subEngines.push(engine)
 	}
 	engine.cache._meta.currentRecalcul = node.explanation.recalculNode

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.65",
+	"version": "1.0.0-beta.66",
 	"description": "UI to explore publicodes computations",
 	"license": "MIT",
 	"types": "dist/index.d.ts",

--- a/packages/react-ui/source/rule/RulePage.tsx
+++ b/packages/react-ui/source/rule/RulePage.tsx
@@ -137,108 +137,109 @@ function Rule({
 	const situation = buildSituationUsedInRule(engine, rule)
 
 	return (
-		<Container id="documentation-rule-root">
-			<RulesNav
-				dottedName={dottedName}
-				mobileMenuPortalId={mobileMenuPortalId}
-				openNavButtonPortalId={openNavButtonPortalId}
-			/>
-			<Article>
-				<DottedNameContext.Provider value={dottedName}>
-					{useSubEngine && (
-						<div
-							style={{
-								display: 'flex',
-								alignItems: 'baseline',
-								flexWrap: 'wrap',
-								margin: '1rem 0',
-								paddingTop: '0.4rem',
-								paddingBottom: '0.4rem',
-							}}
-						>
-							<div>
-								Vous explorez la documentation avec le contexte{' '}
-								<strong>mécanisme recalcul</strong>
-							</div>
-							<div style={{ flex: 1 }} />
-							<div>
-								<RuleLinkWithContext
-									dottedName={dottedName}
-									useSubEngine={false}
-								>
-									Retourner à la version de base
-								</RuleLinkWithContext>
-							</div>
-						</div>
-					)}
-					<RuleHeader dottedName={dottedName} />
-					<section>
-						<Text>{description || question || ''}</Text>
-					</section>
+		<EngineContext.Provider value={engine}>
+			<Container id="documentation-rule-root">
+				<RulesNav
+					dottedName={dottedName}
+					mobileMenuPortalId={mobileMenuPortalId}
+					openNavButtonPortalId={openNavButtonPortalId}
+				/>
+				<Article>
+					<DottedNameContext.Provider value={dottedName}>
+						<RuleHeader dottedName={dottedName} />
+						<section>
+							<Text>{description || question || ''}</Text>
+						</section>
 
-					<p style={{ fontSize: '1.25rem', lineHeight: '2rem' }}>
-						Valeur : {formatValue(rule, { language })}
-						{rule.nodeValue === undefined && rule.unit && (
+						<p style={{ fontSize: '1.25rem', lineHeight: '2rem' }}>
+							Valeur : {formatValue(rule, { language })}
+							{rule.nodeValue === undefined && rule.unit && (
+								<>
+									<br />
+									Unité : {serializeUnit(rule.unit)}
+								</>
+							)}
+						</p>
+
+						{ruleDisabledByItsParent && (
 							<>
-								<br />
-								Unité : {serializeUnit(rule.unit)}
+								<blockquote>
+									Cette règle est <strong>non applicable</strong> car elle
+									appartient à l'espace de nom :{' '}
+									<Explanation node={nullableParent} />
+								</blockquote>
 							</>
 						)}
-					</p>
-
-					{ruleDisabledByItsParent && (
-						<>
-							<blockquote>
-								Cette règle est <strong>non applicable</strong> car elle
-								appartient à l'espace de nom :{' '}
-								<Explanation node={nullableParent} />
-							</blockquote>
-						</>
-					)}
-
-					<h2>Comment cette donnée est-elle calculée ?</h2>
-					<div id="documentation-rule-explanation">
-						<Explanation node={valeur} />
-					</div>
-
-					{rule.rawNode.note && (
-						<>
-							<h3>Note</h3>
-							<div>
-								<Text>{rule.rawNode.note}</Text>
+						{useSubEngine && (
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'baseline',
+									flexWrap: 'wrap',
+									margin: '1rem 0',
+									paddingTop: '0.4rem',
+									paddingBottom: '0.4rem',
+								}}
+							>
+								<div>
+									Les valeurs affichées sont calculées avec la situation
+									spécifique du <strong>mécanisme recalcul</strong>
+								</div>
+								<div style={{ flex: 1 }} />
+								<div>
+									<RuleLinkWithContext
+										dottedName={dottedName}
+										useSubEngine={false}
+									>
+										Retourner à la version de base
+									</RuleLinkWithContext>
+								</div>
 							</div>
-						</>
-					)}
-					{rule.rawNode.références && References && (
-						<>
-							<h3>Références</h3>
-							<References references={rule.rawNode.références} />
-						</>
-					)}
-					<br />
+						)}
+						<h2>Comment cette donnée est-elle calculée ?</h2>
+						<div id="documentation-rule-explanation">
+							<Explanation node={valeur} />
+						</div>
 
-					{showDevSection && (
-						<>
-							<h3>Informations techniques</h3>
-							<Text>
-								Si vous êtes développeur/euse vous trouverez ci-dessous des
-								informations techniques utiles pour l'intégration de cette règle
-								dans votre application.
-							</Text>
-							<DeveloperAccordion
-								engine={engine}
-								situation={situation}
-								dottedName={dottedName}
-								rule={rule}
-								apiDocumentationUrl={apiDocumentationUrl}
-								apiEvaluateUrl={apiEvaluateUrl}
-								npmPackage={npmPackage}
-							></DeveloperAccordion>
-						</>
-					)}
-				</DottedNameContext.Provider>
-			</Article>
-		</Container>
+						{rule.rawNode.note && (
+							<>
+								<h3>Note</h3>
+								<div>
+									<Text>{rule.rawNode.note}</Text>
+								</div>
+							</>
+						)}
+						{rule.rawNode.références && References && (
+							<>
+								<h3>Références</h3>
+								<References references={rule.rawNode.références} />
+							</>
+						)}
+						<br />
+
+						{showDevSection && (
+							<>
+								<h3>Informations techniques</h3>
+								<Text>
+									Si vous êtes développeur/euse vous trouverez ci-dessous des
+									informations techniques utiles pour l'intégration de cette
+									règle dans votre application.
+								</Text>
+								<DeveloperAccordion
+									engine={engine}
+									situation={situation}
+									dottedName={dottedName}
+									rule={rule}
+									apiDocumentationUrl={apiDocumentationUrl}
+									apiEvaluateUrl={apiEvaluateUrl}
+									npmPackage={npmPackage}
+								></DeveloperAccordion>
+							</>
+						)}
+					</DottedNameContext.Provider>
+				</Article>
+			</Container>
+		</EngineContext.Provider>
 	)
 }
 


### PR DESCRIPTION
**publicodes-react**
- Fix the display of explanations in the context of a recalul mecanism (the computed values where those of the base engine before)

**core**
- Recalcul mecanism now use the initial context to compute the values of overrides, instead of using the new one.