### PR TITLE
Feat(core): expose the parseExpression function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
 ## next
+
+## 1.0.0-beta.71
+
+**core**
+
+-   Expose the `parseExpression` function (#370)
+
 ## 1.0.0-beta.70
 
 **publicodes-react**
 
--  Fix crash on documentation when a ‘variable manquante’ mecanism is used with a replacement
+-   Fix crash on documentation when a ‘variable manquante’ mecanism is used with a replacement
 
 ## 1.0.0-beta.69
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.70",
+	"version": "1.0.0-beta.71",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.70",
+	"version": "1.0.0-beta.71",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -62,7 +62,7 @@ export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'
 export { parseUnit, serializeUnit } from './units'
-export { parseExpression, type ExprAST } from './parse'
+export { parseExpression, type ExprAST } from './parseExpression'
 export { parsePublicodes, utils }
 
 export { type Rule, type RuleNode, type ASTNode, type EvaluatedNode }

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -62,7 +62,7 @@ export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'
 export { parseUnit, serializeUnit } from './units'
-export { parseExpression } from './parse'
+export { parseExpression, type ExprAST } from './parse'
 export { parsePublicodes, utils }
 
 export { type Rule, type RuleNode, type ASTNode, type EvaluatedNode }

--- a/packages/core/source/index.ts
+++ b/packages/core/source/index.ts
@@ -62,7 +62,9 @@ export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'
 export { parseUnit, serializeUnit } from './units'
+export { parseExpression } from './parse'
 export { parsePublicodes, utils }
+
 export { type Rule, type RuleNode, type ASTNode, type EvaluatedNode }
 
 export type PublicodesExpression = string | Record<string, unknown> | number

--- a/packages/core/source/parse.ts
+++ b/packages/core/source/parse.ts
@@ -88,6 +88,29 @@ Utilisez leur contrepartie française : 'oui' / 'non'`,
 
 const compiledGrammar = Grammar.fromCompiled(grammar)
 
+type BinaryOp =
+	| { '+': [ExprAST, ExprAST] }
+	| { '-': [ExprAST, ExprAST] }
+	| { '*': [ExprAST, ExprAST] }
+	| { '/': [ExprAST, ExprAST] }
+	| { '>': [ExprAST, ExprAST] }
+	| { '<': [ExprAST, ExprAST] }
+	| { '>=': [ExprAST, ExprAST] }
+	| { '<=': [ExprAST, ExprAST] }
+	| { '=': [ExprAST, ExprAST] }
+	| { '!=': [ExprAST, ExprAST] }
+
+type UnaryOp = { '-': [{ value: 0 }, ExprAST] }
+
+/** AST of a publicodes expression. */
+export type ExprAST =
+	| BinaryOp
+	| UnaryOp
+	| { variable: string }
+	| { constant: { type: 'number'; nodeValue: number }; unité?: string }
+	| { constant: { type: 'boolean'; nodeValue: boolean } }
+	| { constant: { type: 'string' | 'date'; nodeValue: string } }
+
 /**
  * Parse a publicodes expression into an JSON object representing the AST.
  *
@@ -108,10 +131,7 @@ const compiledGrammar = Grammar.fromCompiled(grammar)
  * // returns { "*": [ { constant: { type: "number", nodeValue: 20.3 } }, { variable:"nombre" } ] }
  * ```
  */
-export function parseExpression(
-	rawNode: string,
-	dottedName: string
-): Record<string, unknown> {
+export function parseExpression(rawNode: string, dottedName: string): ExprAST {
 	/* Strings correspond to infix expressions.
 	 * Indeed, a subset of expressions like simple arithmetic operations `3 + (quantity * 2)` or like `salary [month]` are more explicit that their prefixed counterparts.
 	 * This function makes them prefixed operations. */

--- a/packages/core/source/parse.ts
+++ b/packages/core/source/parse.ts
@@ -70,7 +70,9 @@ Utilisez leur contrepartie française : 'oui' / 'non'`,
 		)
 	}
 	const node =
-		typeof rawNode === 'object' ? rawNode : parseExpression(rawNode, context)
+		typeof rawNode === 'object'
+			? rawNode
+			: parseExpression(rawNode, context.dottedName)
 	if ('nodeKind' in node) {
 		return node
 	}
@@ -86,9 +88,26 @@ Utilisez leur contrepartie française : 'oui' / 'non'`,
 
 const compiledGrammar = Grammar.fromCompiled(grammar)
 
-function parseExpression(
-	rawNode,
-	context: Context
+/**
+ * Parse a publicodes expression into an JSON object representing the AST.
+ *
+ * @param rawNode The expression to parse
+ * @param dottedName The dottedName of the rule being parsed
+ *
+ * @returns The parsed expression
+ *
+ * @throws A `SyntaxError` if the expression is invalid
+ * @throws A `PublicodesInternalError` if the parser is unable to parse the expression
+ *
+ * @example
+ * ```ts
+ * parseExpression('20.3 * nombre', 'foo . bar')
+ * // returns { "*": [ { constant: { type: "number", nodeValue: 20.3 } }, { variable:"nombre" } ] }
+ * ```
+ */
+export function parseExpression(
+	rawNode: string,
+	dottedName: string
 ): Record<string, unknown> | undefined {
 	/* Strings correspond to infix expressions.
 	 * Indeed, a subset of expressions like simple arithmetic operations `3 + (quantity * 2)` or like `salary [month]` are more explicit that their prefixed counterparts.
@@ -115,7 +134,7 @@ function parseExpression(
 		throw new PublicodesError(
 			'SyntaxError',
 			`\`${singleLineExpression}\` n'est pas une expression valide`,
-			{ dottedName: context.dottedName },
+			{ dottedName },
 			e
 		)
 	}

--- a/packages/core/source/parse.ts
+++ b/packages/core/source/parse.ts
@@ -91,10 +91,13 @@ const compiledGrammar = Grammar.fromCompiled(grammar)
 /**
  * Parse a publicodes expression into an JSON object representing the AST.
  *
+ * The parsing is done with the [nearley](https://nearley.js.org/) parser based
+ * on the [grammar](https://github.com/betagouv/publicodes/blob/290c079d1f22baed77a96bdd834ef6cb44fa8da9/packages/core/source/grammar.ne)
+ *
  * @param rawNode The expression to parse
  * @param dottedName The dottedName of the rule being parsed
  *
- * @returns The parsed expression
+ * @returns The parsing result as a JSON object
  *
  * @throws A `SyntaxError` if the expression is invalid
  * @throws A `PublicodesInternalError` if the parser is unable to parse the expression
@@ -108,7 +111,7 @@ const compiledGrammar = Grammar.fromCompiled(grammar)
 export function parseExpression(
 	rawNode: string,
 	dottedName: string
-): Record<string, unknown> | undefined {
+): Record<string, unknown> {
 	/* Strings correspond to infix expressions.
 	 * Indeed, a subset of expressions like simple arithmetic operations `3 + (quantity * 2)` or like `salary [month]` are more explicit that their prefixed counterparts.
 	 * This function makes them prefixed operations. */

--- a/packages/core/source/parseExpression.ts
+++ b/packages/core/source/parseExpression.ts
@@ -1,0 +1,90 @@
+import nearley from 'nearley'
+import { PublicodesError } from './error'
+import grammar from './grammar'
+
+// TODO: nearley is currently exported as a CommonJS module which is why we need
+// to destructure the default import instead of directly importing the symbols
+// we need. This is sub-optimal because we our bundler will not tree-shake
+// unused nearley symbols.
+// https://github.com/kach/nearley/issues/535
+const { Grammar, Parser } = nearley
+
+const compiledGrammar = Grammar.fromCompiled(grammar)
+
+type BinaryOp =
+	| { '+': [ExprAST, ExprAST] }
+	| { '-': [ExprAST, ExprAST] }
+	| { '*': [ExprAST, ExprAST] }
+	| { '/': [ExprAST, ExprAST] }
+	| { '>': [ExprAST, ExprAST] }
+	| { '<': [ExprAST, ExprAST] }
+	| { '>=': [ExprAST, ExprAST] }
+	| { '<=': [ExprAST, ExprAST] }
+	| { '=': [ExprAST, ExprAST] }
+	| { '!=': [ExprAST, ExprAST] }
+
+type UnaryOp = { '-': [{ value: 0 }, ExprAST] }
+
+/** AST of a publicodes expression. */
+export type ExprAST =
+	| BinaryOp
+	| UnaryOp
+	| { variable: string }
+	| { constant: { type: 'number'; nodeValue: number }; unité?: string }
+	| { constant: { type: 'boolean'; nodeValue: boolean } }
+	| { constant: { type: 'string' | 'date'; nodeValue: string } }
+
+/**
+ * Parse a publicodes expression into an JSON object representing the AST.
+ *
+ * The parsing is done with the [nearley](https://nearley.js.org/) parser based
+ * on the [grammar](https://github.com/betagouv/publicodes/blob/290c079d1f22baed77a96bdd834ef6cb44fa8da9/packages/core/source/grammar.ne)
+ *
+ * @param rawNode The expression to parse
+ * @param dottedName The dottedName of the rule being parsed
+ *
+ * @returns The parsing result as a JSON object
+ *
+ * @throws A `SyntaxError` if the expression is invalid
+ * @throws A `PublicodesInternalError` if the parser is unable to parse the expression
+ *
+ * @example
+ * ```ts
+ * parseExpression('20.3 * nombre', 'foo . bar')
+ * // returns { "*": [ { constant: { type: "number", nodeValue: 20.3 } }, { variable:"nombre" } ] }
+ * ```
+ */
+export function parseExpression(rawNode: string, dottedName: string): ExprAST {
+	/* Strings correspond to infix expressions.
+	 * Indeed, a subset of expressions like simple arithmetic operations `3 + (quantity * 2)` or like `salary [month]` are more explicit that their prefixed counterparts.
+	 * This function makes them prefixed operations. */
+	const singleLineExpression = (rawNode + '').replace(/\s*\n\s*/g, ' ').trim()
+	try {
+		const [parseResult] = new Parser(compiledGrammar).feed(
+			singleLineExpression
+		).results
+
+		if (parseResult == null) {
+			throw new PublicodesError(
+				'InternalError',
+				`
+Internal problem with the Nearley parser used to parse the expression.
+
+For the expression "${singleLineExpression}", the parser returned no result.
+`,
+				{ dottedName }
+			)
+		}
+		return parseResult
+	} catch (e) {
+		if (e instanceof PublicodesError) {
+			throw e
+		}
+		throw new PublicodesError(
+			'SyntaxError',
+			`\`${singleLineExpression}\` is not a valid expression`,
+			{ dottedName },
+			e
+		)
+	}
+}

--- a/packages/core/test/parseExpression.test.ts
+++ b/packages/core/test/parseExpression.test.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai'
+import { parseExpression } from '../source/index'
+
+describe("Enables external codebases to use publicodes's expression parser", () => {
+	it('should parse a basic expression', () => {
+		const parsed = parseExpression('équipement * facteur', 'foo . bar')
+		expect(JSON.stringify(parsed)).to.equal(
+			JSON.stringify({
+				'*': [
+					{
+						variable: 'équipement',
+					},
+					{
+						variable: 'facteur',
+					},
+				],
+			})
+		)
+	})
+})

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.70",
+	"version": "1.0.0-beta.71",
 	"description": "UI to explore publicodes computations",
 	"license": "MIT",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This PR takes over from https://github.com/betagouv/publicodes/pull/368, exposing the function `parseExpression`.

Example of usage in publiopti : https://github.com/incubateur-ademe/publiopti/pull/12

Are you ok with this @johangirod and @mquandalle ?