### PR TITLE
fix(core): switch back to french error messages

### DIFF
--- a/packages/core/source/parseExpression.ts
+++ b/packages/core/source/parseExpression.ts
@@ -68,9 +68,9 @@ export function parseExpression(rawNode: string, dottedName: string): ExprAST {
 			throw new PublicodesError(
 				'InternalError',
 				`
-Internal problem with the Nearley parser used to parse the expression.
+Un problème est survenu lors du parsing de l'expression \`${singleLineExpression}\` :
 
-For the expression "${singleLineExpression}", the parser returned no result.
+	le parseur Nearley n'a pas réussi à parser l'expression.
 `,
 				{ dottedName }
 			)
@@ -82,7 +82,7 @@ For the expression "${singleLineExpression}", the parser returned no result.
 		}
 		throw new PublicodesError(
 			'SyntaxError',
-			`\`${singleLineExpression}\` is not a valid expression`,
+			`\`${singleLineExpression}\` n'est pas une expression valide`,
 			{ dottedName },
 			e
 		)


### PR DESCRIPTION
Go back to a error messages in french to avoid the following CI error : https://github.com/betagouv/publicodes/actions/runs/5645005382/job/15289929508 