### PR TITLE
Passage à la version beta-77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,47 @@
 # Changelog
 
 ## next
+
+## 1.0.0-beta.77
+
+-   Améliore la gestion des unités (#374)
+-   Améliore le message d'erreur pour les opérations
+-   Permet de convertir correctement un dénominateur produit
+-   Première fonction de gestion d'unité "puissance"
+-   Ajout d'une première table d'unités équivalentes
+-   Nouveaux tests
+
 ## 1.0.0-beta.76
-- Fix `engine.inversionFail` dont la valeur était réinitialisée à chaque appel de `engine.evaluate`
+
+-   Fix `engine.inversionFail` dont la valeur était réinitialisée à chaque appel de `engine.evaluate`
 
 ## 1.0.0-beta.75
 
-- Remove yaml package from publicodes-react and use json instead
-- Use hash instead of url parameter in doc by default
-- Replace `react-monaco-editor` by `@monaco-editor/react` which add yaml coloration
-- Update packages: docusaurus, tsup, typescript, vitest, and more
-- Fix console.log à supprimer #379
+-   Remove yaml package from publicodes-react and use json instead
+-   Use hash instead of url parameter in doc by default
+-   Replace `react-monaco-editor` by `@monaco-editor/react` which add yaml coloration
+-   Update packages: docusaurus, tsup, typescript, vitest, and more
+-   Fix console.log à supprimer #379
 
 ## 1.0.0-beta.74
 
 **core**
-- 30% d'amélioration des perfs de parsing grâce à des micros optimisations
+
+-   30% d'amélioration des perfs de parsing grâce à des micros optimisations
 
 ## 1.0.0-beta.73
+
 **publicodes-react**
 
-- Corrige un bug de style suite à la mise à jour de styled component v6
-- Cache les élements non applicable par défaut dans les mécanismes de type liste, et ajoute un bouton « Afficher les valeurs non applicables ».
+-   Corrige un bug de style suite à la mise à jour de styled component v6
+-   Cache les élements non applicable par défaut dans les mécanismes de type liste, et ajoute un bouton « Afficher les valeurs non applicables ».
 
 ## 1.0.0-beta.72
+
 **publicodes-react**
 
-- Corrige un bug dans la compilation esm de react-ui
-- BREAKING : passe à styled component v6
+-   Corrige un bug dans la compilation esm de react-ui
+-   BREAKING : passe à styled component v6
 
 ## 1.0.0-beta.71
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@publicodes/api",
-	"version": "1.0.0-beta.76",
+	"version": "1.0.0-beta.77",
 	"description": "Publicodes API",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes",
-	"version": "1.0.0-beta.76",
+	"version": "1.0.0-beta.77",
 	"description": "A declarative language for encoding public algorithm",
 	"types": "dist/index.d.ts",
 	"type": "module",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "publicodes-react",
-	"version": "1.0.0-beta.76",
+	"version": "1.0.0-beta.77",
 	"description": "UI to explore publicodes computations",
 	"license": "MIT",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
@EmileRolley @johangirod, suite à #374, j'ai oublié de mettre à jour la version (je le fais ici) et j'aimerais publier le nouveau paquet, du coup qques questions:

- L'upgrade de la version peut il se faire automatiquement ? Via une commande ? Je l'ai fait à la main ici
- Peut-on publier une nouvelle version sur nom à partir du moment ou nous sommes dans l'orga Publicodes ?
- J'ai des soucis avec Prettier visiblement pour le md, c'est un pb de mon côté ?


Peut etre un premier élément de réponse ici: https://github.com/betagouv/publicodes/actions/runs/6483400025/job/17604888653

La publication du paquet a fail car j'ai oublié d'upgrader la version?